### PR TITLE
Sync deasy-docs with the `unstructured-sdk` 0.21.0 release

### DIFF
--- a/deasy-openapi-stainless.yml
+++ b/deasy-openapi-stainless.yml
@@ -48,6 +48,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -61,12 +67,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -74,20 +78,99 @@ paths:
           ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
           UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
           connector_response = client.data_source.create(\n    connector_body={\n\
-          \        \"collection_name\": \"collection_name\",\n        \"database_name\"\
-          : \"database_name\",\n        \"db_user\": \"db_user\",\n        \"name\"\
-          : \"name\",\n        \"password\": \"password\",\n        \"port\": \"port\"\
-          ,\n        \"url\": \"url\",\n    },\n    connector_name=\"connector_name\"\
-          ,\n)\nprint(connector_response.profile_id)"
+          \        \"client_id\": \"client_id\",\n        \"client_secret\": \"client_secret\"\
+          ,\n        \"name\": \"name\",\n        \"tenant_id\": \"tenant_id\",\n\
+          \        \"type\": \"OnedriveDataSourceManager\",\n    },\n    connector_name=\"\
+          connector_name\",\n)\nprint(connector_response.profile_id)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst connectorResponse\
-          \ = await client.dataSource.create({\n  connector_body: {\n    collection_name:\
-          \ 'collection_name',\n    database_name: 'database_name',\n    db_user:\
-          \ 'db_user',\n    name: 'name',\n    password: 'password',\n    port: 'port',\n\
-          \    url: 'url',\n  },\n  connector_name: 'connector_name',\n});\n\nconsole.log(connectorResponse.profile_id);"
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst connectorResponse = await\
+          \ client.dataSource.create({\n  connector_body: {\n    client_id: 'client_id',\n\
+          \    client_secret: 'client_secret',\n    name: 'name',\n    tenant_id:\
+          \ 'tenant_id',\n    type: 'OnedriveDataSourceManager',\n  },\n  connector_name:\
+          \ 'connector_name',\n});\n\nconsole.log(connectorResponse.profile_id);"
+  /data_connector/create_batch:
+    post:
+      tags:
+      - Data Connectors
+      summary: Batch Create
+      description: Create multiple data connectors in a single call. Useful for multi-site
+        SharePoint connections where each site is a separate connector.
+      operationId: create_data_sources_batch_route_data_connector_create_batch_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchCreateVDBConnectorRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchConnectorResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_source.create_batch(\n    connectors=[{\n       \
+          \ \"connector_body\": {\n            \"client_id\": \"client_id\",\n   \
+          \         \"client_secret\": \"client_secret\",\n            \"name\": \"\
+          name\",\n            \"tenant_id\": \"tenant_id\",\n            \"type\"\
+          : \"OnedriveDataSourceManager\",\n        },\n        \"connector_name\"\
+          : \"connector_name\",\n    }],\n)\nprint(response.profile_ids)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.createBatch({\n\
+          \  connectors: [\n    {\n      connector_body: {\n        client_id: 'client_id',\n\
+          \        client_secret: 'client_secret',\n        name: 'name',\n      \
+          \  tenant_id: 'tenant_id',\n        type: 'OnedriveDataSourceManager',\n\
+          \      },\n      connector_name: 'connector_name',\n    },\n  ],\n});\n\n\
+          console.log(response.profile_ids);"
   /data_connector/update:
     post:
       tags:
@@ -131,6 +214,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -144,12 +233,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -157,20 +244,20 @@ paths:
           ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
           UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
           connector_response = client.data_source.update(\n    connector_body={\n\
-          \        \"collection_name\": \"collection_name\",\n        \"database_name\"\
-          : \"database_name\",\n        \"db_user\": \"db_user\",\n        \"name\"\
-          : \"name\",\n        \"password\": \"password\",\n        \"port\": \"port\"\
-          ,\n        \"url\": \"url\",\n    },\n    connector_name=\"connector_name\"\
-          ,\n)\nprint(connector_response.profile_id)"
+          \        \"client_id\": \"client_id\",\n        \"client_secret\": \"client_secret\"\
+          ,\n        \"name\": \"name\",\n        \"tenant_id\": \"tenant_id\",\n\
+          \        \"type\": \"OnedriveDataSourceManager\",\n    },\n    connector_name=\"\
+          connector_name\",\n)\nprint(connector_response.profile_id)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst connectorResponse\
-          \ = await client.dataSource.update({\n  connector_body: {\n    collection_name:\
-          \ 'collection_name',\n    database_name: 'database_name',\n    db_user:\
-          \ 'db_user',\n    name: 'name',\n    password: 'password',\n    port: 'port',\n\
-          \    url: 'url',\n  },\n  connector_name: 'connector_name',\n});\n\nconsole.log(connectorResponse.profile_id);"
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst connectorResponse = await\
+          \ client.dataSource.update({\n  connector_body: {\n    client_id: 'client_id',\n\
+          \    client_secret: 'client_secret',\n    name: 'name',\n    tenant_id:\
+          \ 'tenant_id',\n    type: 'OnedriveDataSourceManager',\n  },\n  connector_name:\
+          \ 'connector_name',\n});\n\nconsole.log(connectorResponse.profile_id);"
   /data_connector/list:
     post:
       tags:
@@ -217,6 +304,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -226,10 +317,11 @@ paths:
           list_vdb_connector = client.data_source.list()\nprint(list_vdb_connector.connectors)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst listVdbConnector\
-          \ = await client.dataSource.list();\n\nconsole.log(listVdbConnector.connectors);"
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst listVdbConnector = await\
+          \ client.dataSource.list();\n\nconsole.log(listVdbConnector.connectors);"
   /data_connector/delete:
     post:
       tags:
@@ -271,6 +363,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -284,12 +382,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -300,11 +396,155 @@ paths:
           ,\n)\nprint(connector_response.profile_id)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst connectorResponse\
-          \ = await client.dataSource.delete({ connector_name: 'connector_name' });\n\
-          \nconsole.log(connectorResponse.profile_id);"
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst connectorResponse = await\
+          \ client.dataSource.delete({ connector_name: 'connector_name' });\n\nconsole.log(connectorResponse.profile_id);"
+  /data_connector/delete_batch:
+    post:
+      tags:
+      - Data Connectors
+      summary: Batch Delete
+      description: Delete multiple data connectors in a single call. Useful for removing
+        all connectors in a multi-site group.
+      operationId: delete_data_sources_batch_route_data_connector_delete_batch_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BatchDeleteConnectorRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BatchDeleteConnectorResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_source.delete_batch(\n    connector_names=[\"string\"\
+          ],\n)\nprint(response.deleted)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.deleteBatch({\
+          \ connector_names: ['string'] });\n\nconsole.log(response.deleted);"
+  /connector/set_active_profile:
+    post:
+      tags:
+      - Data Connectors
+      summary: Set Active Connector
+      description: "Set the active connector\n\nAttributes:\n\n    connector_name:\
+        \ The profile name of the connector to set as active.\n    connector_type:\
+        \ The type of connector to set as active, either \"vdb\" or \"llm\"."
+      operationId: set_active_connector_connector_set_active_profile_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SetActiveConnectorRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConnectorResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          connector_response = client.data_source.set_active_profile(\n    connector_name=\"\
+          connector_name\",\n    connector_type=\"vdb\",\n)\nprint(connector_response.profile_id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst connectorResponse = await\
+          \ client.dataSource.setActiveProfile({\n  connector_name: 'connector_name',\n\
+          \  connector_type: 'vdb',\n});\n\nconsole.log(connectorResponse.profile_id);"
   /ocr/ingest:
     post:
       tags:
@@ -354,6 +594,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -367,12 +613,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -383,11 +627,172 @@ paths:
           ,\n)\nprint(response)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.dataSource.ingest({ data_connector_name: 'data_connector_name'\
-          \ });\n\nconsole.log(response);"
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.ingest({\
+          \ data_connector_name: 'data_connector_name' });\n\nconsole.log(response);"
+  /ocr/sync_stats:
+    post:
+      tags:
+      - Data Connectors
+      summary: Ocr Sync Stats
+      description: 'Get OCR sync statistics for multiple data connectors from cached
+        database values.
+
+
+        This endpoint only retrieves pre-calculated statistics from the database.
+
+        If stats are older than 15 minutes, a background task is triggered to refresh
+        them.'
+      operationId: ocr_sync_stats_ocr_sync_stats_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OCRSyncStatsRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_source.sync_stats(\n    data_connector_names=[\"\
+          string\"],\n)\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.syncStats({\
+          \ data_connector_names: ['string'] });\n\nconsole.log(response);"
+  /ocr/list_source_files:
+    post:
+      tags:
+      - Data Connectors
+      summary: List Source Files
+      description: "List files available for ingestion from a data source (S3, SharePoint).\n\
+        \nThis endpoint queries the actual source storage (not the vector DB) to show\
+        \ files \nbefore they are ingested. Use this to enable selective file ingestion.\n\
+        \n## Request Body\n\n| Field                 | Type     | Description    \
+        \                                  |\n|-----------------------|----------|--------------------------------------------------|\n\
+        | `data_connector_name` | `str`    | Name of the data connector to query \
+        \             |\n| `prefix`              | `str`    | Optional path prefix\
+        \ to filter files             |\n| `search_query`        | `str`    | Optional\
+        \ filename search (case-insensitive)      |\n| `limit`               | `int`\
+        \    | Max files to return (default: 1000, max: 10000)  |\n| `offset`    \
+        \          | `int`    | Number of files to skip for pagination           |\n\
+        \n## Response\n\n- `files`: List of file objects with path, size, last_modified\n\
+        - `total_count`: Total number of matching files in the source\n- `next_offset`:\
+        \ Offset for next page (null if no more pages)\n- `selection_enabled`: False\
+        \ if total_count > 10000 (use full ingestion instead)"
+      operationId: list_source_files_ocr_list_source_files_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListSourceFilesRequest'
+        required: true
+      responses:
+        '200':
+          description: Files listed successfully
+          content:
+            application/json:
+              schema: {}
+        '400':
+          description: Invalid request or unsupported connector type
+        '401':
+          description: Invalid or expired credentials
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Data connector not found
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '502':
+          description: Failed to connect to data source
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_source.list_source_files(\n    data_connector_name=\"\
+          data_connector_name\",\n)\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.listSourceFiles({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(response);"
   /data/metadata/list:
     post:
       tags:
@@ -443,6 +848,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -456,12 +867,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -472,1003 +881,24 @@ paths:
           data_connector_name\",\n)\nprint(response.metadata)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.dataSource.listIngestedData({\n  data_connector_name: 'data_connector_name',\n\
-          });\n\nconsole.log(response.metadata);"
-  /tags/upsert:
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.listIngestedData({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(response.metadata);"
+  /data/list_paginated:
     post:
       tags:
-      - Tags
-      summary: Upsert
-      description: "Insert or update a tag definition.\n\n## Request Body\n\n| Field\
-        \      | Type            | Description                                   \
-        \   |\n|------------|-----------------|--------------------------------------------------|\n\
-        | `tag_data` | `Tag` | Tag data structure containing tag definition.    |\n\
-        \n## Response\n\n- **200**: Tag upserted successfully  \n    - Returns: `{\
-        \ \"tag_name\": str, \"tag\": Tag, \"available_values_added\": List[str] }`\n\
-        - **400**: Bad Request (e.g., invalid tag data)\n- **500**: Internal Server\
-        \ Error\n\n## Example\n\n```json\n{\n  \"tag_data\": {\n    \"name\": \"category\"\
-        ,\n    \"description\": \"Document category classification\",\n    \"type\"\
-        : \"select\",\n    \"available_values\": [\"invoice\", \"receipt\", \"contract\"\
-        ]\n  }\n}\n```"
-      operationId: upsert_tag_route_tags_upsert_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpsertTagRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpsertTagResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          response = client.tags.upsert(\n    tag_data={\n        \"name\": \"name\"\
-          \n    },\n)\nprint(response.available_values_added)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.tags.upsert({ tag_data: { name: 'name' } });\n\nconsole.log(response.available_values_added);"
-  /tags/list:
-    get:
-      tags:
-      - Tags
-      summary: List
-      description: "List all tags for the authenticated user.\n\n## Response\n\n-\
-        \ **200**: Tags retrieved successfully  \n    - Returns: `{ \"tags\": List[Tag]\
-        \ }`\n- **500**: Internal Server Error\n\n## Example Response\n\n```json\n\
-        {\n  \"tags\": [\n    {\n      \"name\": \"category\",\n      \"description\"\
-        : \"Document category\",\n      \"type\": \"select\",\n      \"available_values\"\
-        : [\"invoice\", \"receipt\"]\n    },\n    {\n      \"name\": \"date\",\n \
-        \     \"description\": \"Document date\",\n      \"type\": \"date\"\n    }\n\
-        \  ]\n}\n```"
-      operationId: list_tags_route_tags_list_get
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListTagsResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          tags = client.tags.list()\nprint(tags.tags)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst tags = await client.tags.list();\n\
-          \nconsole.log(tags.tags);"
-  /tags/delete:
-    delete:
-      tags:
-      - Tags
-      summary: Delete
-      description: "Delete a tag by name. Tag must not be in use by any graphs or\
-        \ dataslices.\n\n## Query Parameters\n\n| Parameter  | Type  | Description\
-        \                          |\n|------------|-------|--------------------------------------|\n\
-        | `tag_name` | `str` | Name of the tag to delete.           |\n\n## Response\n\
-        \n- **200**: Tag deleted successfully  \n    - Returns: `{ \"tag_name\": str\
-        \ }`\n- **500**: Internal Server Error (e.g., tag still in use)\n\n## Example\n\
-        \n```\nDELETE /tags/delete?tag_name=category\n```"
-      operationId: delete_tag_route_tags_delete_delete
-      parameters:
-      - name: tag_name
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Tag Name
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TagResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          tag_response = client.tags.delete(\n    tag_name=\"tag_name\",\n)\nprint(tag_response.tag_name)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst tagResponse =\
-          \ await client.tags.delete({ tag_name: 'tag_name' });\n\nconsole.log(tagResponse.tag_name);"
-  /suggest_regex:
-    post:
-      tags:
-      - Tags
-      summary: Suggest Patterns
-      description: "Generate a regex pattern based on a natural language description\
-        \ using AI.\n\n## Request Body\n\n| Field              | Type           |\
-        \ Description                                                            \
-        \                  |\n|--------------------|----------------|------------------------------------------------------------------------------------------|\n\
-        | `description`      | `str`          | Natural language description of what\
-        \ to match (e.g., \"phone numbers in format (XXX) XXX-XXXX\"). |\n| `examples`\
-        \         | `List[str]`    | Optional. List of example strings that should\
-        \ match the pattern.                         |\n\n## Response\n\n- **200**:\
-        \ Regex pattern generated successfully  \n    - Returns: `{ \"regex\": str\
-        \ }`\n- **400**: Bad Request (e.g., invalid request data)\n- **500**: Internal\
-        \ Server Error\n\n## Example\n\n```json\n{\n  \"description\": \"phone numbers\
-        \ in format (XXX) XXX-XXXX\",\n  \"examples\": [\n    \"(123) 456-7890\",\n\
-        \    \"(555) 123-4567\"\n  ]\n}\n```\n\n## Example Response\n\n```json\n{\n\
-        \  \"regex\": \"\\(\\d{3}\\) \\d{3}-\\d{4}\",\n}\n```"
-      operationId: suggest_patterns_route_suggest_regex_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/SuggestRegexRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SuggestRegexResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          response = client.tags.pattern.suggest_patterns(\n    pattern_description=\"\
-          pattern_description\",\n    tag_data={\n        \"name\": \"name\"\n   \
-          \ },\n)\nprint(response.confidence_score)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.tags.pattern.suggestPatterns({\n  pattern_description: 'pattern_description',\n\
-          \  tag_data: { name: 'name' },\n});\n\nconsole.log(response.confidence_score);"
-  /taxonomy/upsert:
-    post:
-      tags:
-      - Taxonomies
-      summary: Upsert
-      description: "Insert or update a taxonomy (schema/hierarchy) in the database.\n\
-        \n## Request Body\n\n| Field                  | Type             | Description\
-        \                                                          |\n|------------------------|------------------|----------------------------------------------------------------------|\n\
-        | `taxonomy_name`        | `str`            | Name of the taxonomy to upsert.\
-        \                                      |\n| `new_taxonomy_name`    | `Optional[str]`\
-        \  | New name for the taxonomy (when updating).                          \
-        \ |\n| `taxonomy_description` | `Optional[str]`  | Description of the taxonomy.\
-        \                                         |\n| `taxonomy_data`        | `Optional[Dict]`\
-        \ | The taxonomy/hierarchy data structure.                               |\n\
-        \n## Response\n\n- **200**: Taxonomy upserted successfully  \n    - Returns:\
-        \ `{ \"taxonomy_name\": str }`\n- **500**: Internal Server Error\n\n## Example\n\
-        \n```json\n{\n  \"taxonomy_name\": \"document-categories\",\n  \"taxonomy_description\"\
-        : \"Main document classification taxonomy\",\n  \"taxonomy_data\": {\n   \
-        \ \"invoice\": [\"purchase_invoice\", \"sales_invoice\"],\n    \"receipt\"\
-        : [\"expense_receipt\", \"payment_receipt\"]\n  }\n}\n```"
-      operationId: upsert_taxonomy_route_taxonomy_upsert_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpsertTaxonomyRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TaxonomyOperationResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          taxonomy_operation_response = client.taxonomy.upsert(\n    taxonomy_name=\"\
-          taxonomy_name\",\n)\nprint(taxonomy_operation_response.taxonomy_name)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst taxonomyOperationResponse\
-          \ = await client.taxonomy.upsert({ taxonomy_name: 'taxonomy_name' });\n\n\
-          console.log(taxonomyOperationResponse.taxonomy_name);"
-  /taxonomy/list:
-    post:
-      tags:
-      - Taxonomies
-      summary: List
-      description: "List all taxonomies (schemas/hierarchies) for the authenticated\
-        \ user.\n\n## Request Body\n\n| Field          | Type                  | Description\
-        \                                                          |\n|----------------|-----------------------|----------------------------------------------------------------------|\n\
-        | `taxonomy_ids` | `Optional[List[str]]` | List of specific taxonomy IDs to\
-        \ retrieve. If omitted, returns all taxonomies. |\n\n## Response\n\n- **200**:\
-        \ Taxonomies retrieved successfully  \n    - Returns: `{ \"taxonomies\": List[DeasyTaxonomy]\
-        \ }`\n- **500**: Internal Server Error\n\n## Example\n\n```json\n{\n  \"taxonomy_ids\"\
-        : [\"document-categories\", \"sentiment-types\"]\n}\n```"
-      operationId: list_taxonomies_route_taxonomy_list_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ListTaxonomiesRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListTaxonomiesResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          taxonomies = client.taxonomy.list()\nprint(taxonomies.taxonomies)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst taxonomies = await\
-          \ client.taxonomy.list();\n\nconsole.log(taxonomies.taxonomies);"
-  /taxonomy/delete:
-    delete:
-      tags:
-      - Taxonomies
-      summary: Delete
-      description: "Delete a taxonomy (schema/hierarchy) by name.\n\n## Query Parameters\n\
-        \n| Parameter       | Type  | Description                             |\n\
-        |-----------------|-------|-----------------------------------------|\n| `taxonomy_name`\
-        \ | `str` | Name of the taxonomy to delete.         |\n\n## Response\n\n-\
-        \ **200**: Taxonomy deleted successfully  \n    - Returns: `{ \"taxonomy_name\"\
-        : str }`\n- **500**: Internal Server Error\n\n## Example\n\n```\nDELETE /taxonomy/delete?taxonomy_name=document-categories\n\
-        ```"
-      operationId: delete_taxonomy_route_taxonomy_delete_delete
-      parameters:
-      - name: taxonomy_name
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Taxonomy Name
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/TaxonomyOperationResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          taxonomy_operation_response = client.taxonomy.delete(\n    taxonomy_name=\"\
-          taxonomy_name\",\n)\nprint(taxonomy_operation_response.taxonomy_name)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst taxonomyOperationResponse\
-          \ = await client.taxonomy.delete({ taxonomy_name: 'taxonomy_name' });\n\n\
-          console.log(taxonomyOperationResponse.taxonomy_name);"
-  /suggest_schema:
-    post:
-      tags:
-      - Taxonomies
-      summary: Suggest
-      description: "Suggest a tag taxonomy based on file content and existing metadata.\n\
-        \n## Request Body\n\n| Field                   | Type                   |\
-        \ Description                                                            \
-        \      |\n|-------------------------|------------------------|------------------------------------------------------------------------------|\n\
-        | `data_connector_name`   | `str`                  | Name of the data connector\
-        \ (vector database profile) to use.                 |\n| `file_names`    \
-        \        | `Optional[List[str]]`  | List of specific files to analyze for\
-        \ the hierarchy suggestion.              |\n| `dataslice_id`          | `Optional[str]`\
-        \        | ID of a dataslice to pull files from for the suggestion.      \
-        \               |\n| `progress_tracking_id`  | `Optional[str]`        | Custom\
-        \ tracking ID for monitoring the suggestion progress.                   |\n\
-        | `taxonomy_name`           | `Optional[str]`        | Name for the suggested\
-        \ schema/taxonomy.                                      |\n| `current_tree`\
-        \          | `Optional[Dict]`       | Existing hierarchy tree to build upon.\
-        \                                       |\n| `condition`             | `Optional[Condition]`\
-        \  | Filtering condition to select specific files for analysis.          \
-        \         |\n| `node`                  | `Optional[GraphNode]`  | Node location\
-        \ in the existing hierarchy tree to build upon. Default: `{}`    |\n| `user_context`\
-        \          | `Optional[str]`        | User-provided context to guide the suggestion\
-        \ process.                       |\n| `context_level`         | `Optional[str]`\
-        \        | Level at which to analyze content: `file` or `chunk`. Default:\
-        \ `\"file\"`      |\n| `max_height`            | `Optional[int]`        |\
-        \ Maximum depth of the generated hierarchy tree. Default: `2`            \
-        \      |\n| `use_existing_tags`     | `Optional[bool]`       | Whether to\
-        \ incorporate existing tags in suggestions. Default: `false`        |\n| `use_extracted_tags`\
-        \    | `Optional[bool]`       | Whether to use previously extracted tags.\
-        \ Default: `false`                   |\n| `use_mix_llm_and_source`| `Optional[bool]`\
-        \       | Whether to mix LLM-generated and source-based tags. Default: `false`\
-        \         |\n\n## Response\n\n- **200**: Schema suggestion generated successfully\
-        \  \n    - Returns: `{ \"status_code\": int, \"message\": str, \"suggestion\"\
-        : Dict, \"suggested_tags\": Optional[Dict], \"node\": Optional[GraphNode],\
-        \ \"tag_not_found_rates\": Optional[Dict] }`\n- **500**: Internal Server Error\n\
-        \n## Example\n\n```json\n{\n  \"data_connector_name\": \"my-connector\",\n\
-        \  \"file_names\": [\"document1.pdf\", \"document2.pdf\"],\n  \"context_level\"\
-        : \"file\",\n  \"max_height\": 3,\n  \"use_existing_tags\": true,\n  \"user_context\"\
-        : \"Suggest categories for financial documents\"\n}\n```"
-      operationId: suggest_schema_route_suggest_schema_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/MetadataSuggestionRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/MetadataSuggestionResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          response = client.taxonomy.suggest(\n    data_connector_name=\"data_connector_name\"\
-          ,\n)\nprint(response.suggestion)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.taxonomy.suggest({ data_connector_name: 'data_connector_name' });\n\
-          \nconsole.log(response.suggestion);"
-  /classify:
-    post:
-      tags:
-      - Metadata
-      summary: Generate
-      description: "Classify specified files with the provided tags.\nTo run sensitivity\
-        \ detection, use tags with a strategy of SENSITIVITY or a group which includes\
-        \ the magic word \"Sensitivity\"\n\n## Request Body\n\n| Field           \
-        \      | Type                  | Description                             \
-        \                                     |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
-        | `data_connector_name` | `str`                 | Name of the data connector\
-        \ (vector database profile) to use for classification. |\n| `file_names` \
-        \         | `Optional[List[str]]` | Names of specific files to classify. \
-        \                                        |\n| `tag_names`           | `Optional[List[str]]`\
-        \ | Names of tags to use for classification (if `tag_datas` not provided).\
-        \       |\n| `tag_datas`           | `Optional[Dict]`      | Tag data to use\
-        \ for classification.                                          |\n| `overwrite`\
-        \           | `bool`                | Whether to overwrite existing tags.\
-        \ Default: `false`                         |\n| `job_id`              | `Optional[str]`\
-        \       | Custom job ID for tracking the classification task.            \
-        \              |\n| `soft_run`            | `bool`                | If `true`,\
-        \ classification will not save to Deasy and will return results. Default:\
-        \ `false` |\n| `hierarchy_name`      | `Optional[str]`       | Name of the\
-        \ hierarchy/taxonomy to use (if `hierarchy_data` not provided).       |\n\
-        | `hierarchy_data`      | `Optional[Dict]`      | Hierarchy/taxonomy data\
-        \ to use for classification. Default: `{}`                |\n| `dataslice_id`\
-        \        | `Optional[str]`       | ID of the dataslice to use for file filtering.\
-        \                               |\n\n## Response\n\n- **200**: Classification\
-        \ completed or job started successfully  \n    - Returns: `{ \"message\":\
-        \ str, \"job_id\": str, \"results\": Optional[Dict] }`\n- **500**: Internal\
-        \ Server Error\n\n## Example\n\n```json\n{\n  \"data_connector_name\": \"\
-        my-connector\",\n  \"file_names\": [\"document1.pdf\", \"document2.pdf\"],\n\
-        \  \"tag_names\": [\"category\", \"sentiment\"],\n  \"overwrite\": false,\n\
-        \  \"soft_run\": false\n}\n```"
-      operationId: generate_route_classify_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ClassifyRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClassifyResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          response = client.metadata.generate.generate(\n    data_connector_name=\"\
-          data_connector_name\",\n)\nprint(response.message)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.metadata.generate.generate({\n  data_connector_name: 'data_connector_name',\n\
-          });\n\nconsole.log(response.message);"
-  /classify_bulk:
-    post:
-      tags:
-      - Metadata
-      summary: Generate Batch
-      description: "Classify all files in a data connector in batches with the provided\
-        \ tags. \nTo run sensitivity detection, use tags with a strategy of SENSITIVITY\
-        \ or a group which includes the magic word \"Sensitivity\"\n\n## Request Body\n\
-        \n| Field                 | Type                  | Description          \
-        \                                                        |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
-        | `data_connector_name` | `str`                 | Name of the data connector\
-        \ (vector database profile) to use for classification. |\n| `total_data_sets`\
-        \     | `Optional[int]`       | Total number of files to classify.       \
-        \                                    |\n| `tag_names`           | `Optional[List[str]]`\
-        \ | Names of tags to use for classification (if `tag_datas` not provided).\
-        \       |\n| `tag_datas`           | `Optional[Dict]`      | Tag data to use\
-        \ for classification.                                          |\n| `overwrite`\
-        \           | `bool`                | Whether to overwrite existing tags.\
-        \ Default: `false`                         |\n| `job_id`              | `Optional[str]`\
-        \       | Custom job ID for tracking the classification task.            \
-        \              |\n| `hierarchy_name`      | `Optional[str]`       | Name of\
-        \ the hierarchy/taxonomy to use (if `hierarchy_data` not provided).      \
-        \ |\n| `hierarchy_data`      | `Optional[Dict]`      | Hierarchy/taxonomy\
-        \ data to use for classification. Default: `{}`                |\n| `dataslice_id`\
-        \        | `Optional[str]`       | ID of the dataslice to use for file filtering.\
-        \                               |\n| `conditions`          | `Optional[Condition]`\
-        \ | Conditions to use for file filtering.                                \
-        \        |\n\n## Response\n\n- **200**: Classification job started successfully\
-        \  \n    - Returns: `{ \"message\": str, \"job_id\": str }`\n- **500**: Internal\
-        \ Server Error\n\n## Example\n\n```json\n{\n  \"data_connector_name\": \"\
-        my-connector\",\n  \"tag_names\": [\"category\", \"sentiment\"],\n  \"overwrite\"\
-        : false,\n  \"dataslice_id\": \"abc123\"\n}\n```"
-      operationId: generate_batch_route_classify_bulk_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ClassifyBulkRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ClassifyBulkResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          response = client.metadata.generate.generate_batch(\n    data_connector_name=\"\
-          data_connector_name\",\n)\nprint(response.message)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.metadata.generate.generateBatch({\n  data_connector_name: 'data_connector_name',\n\
-          });\n\nconsole.log(response.message);"
-  /metadata/upsert:
-    post:
-      tags:
-      - Metadata
-      summary: Upsert
-      description: "Insert or update metadata for files and tags.\n\n## Request Body\n\
-        \n| Field                 | Type                  | Description          \
-        \                                                        |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
-        | `data_connector_name` | `Optional[str]`       | Name of the data connector\
-        \ (vector database profile).                        |\n| `dataslice_id`  \
-        \      | `Optional[str]`       | ID of the dataslice to upsert metadata for.\
-        \                                  |\n| `metadata`            | `Deasy_Metadata`\
-        \      | Metadata to upsert in the form `{file_name: {tag_name: tag_value}}`.\
-        \         |\n\n## Response\n\n- **200**: Metadata upserted successfully  \n\
-        \    - Returns: `{ \"success\": bool }`\n- **500**: Internal Server Error\n\
-        \n## Example\n\n```json\n{\n  \"data_connector_name\": \"my-connector\",\n\
-        \  \"metadata\": {\n    \"document1.pdf\": {\n      \"category\": \"invoice\"\
-        ,\n      \"date\": \"2024-01-15\"\n    },\n    \"document2.pdf\": {\n    \
-        \  \"category\": \"receipt\",\n      \"status\": \"processed\"\n    }\n  }\n\
-        }\n```"
-      operationId: upsert_metadata_route_metadata_upsert_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpsertMetadataRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UpsertMetadataResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          response = client.metadata.upsert(\n    metadata={\n        \"foo\": {\n\
-          \            \"foo\": {}\n        }\n    },\n)\nprint(response.success)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.metadata.upsert({ metadata: { foo: { foo: {} } } });\n\nconsole.log(response.success);"
-  /metadata/list:
-    post:
-      tags:
-      - Metadata
-      summary: List
-      description: "Get filtered metadata based on conditions. Supports shared connections.\n\
-        \n## Request Body\n\n| Field                 | Type                  | Description\
-        \                                                                  |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
-        | `data_connector_name` | `str`                 | Name of the data connector\
-        \ (vector database profile).                        |\n| `dataslice_id`  \
-        \      | `Optional[str]`       | ID of the dataslice to get files from.  \
-        \                                     |\n| `tag_names`           | `Optional[List[str]]`\
-        \ | List of tag names to include in the metadata.                        \
-        \        |\n| `include_chunk_level` | `Optional[bool]`      | Whether to include\
-        \ chunk-level metadata. Default: `true`                     |\n| `file_names`\
-        \          | `Optional[List[str]]` | List of specific file names to include\
-        \ in the metadata.                      |\n| `chunk_ids`           | `Optional[List[str]]`\
-        \ | List of specific chunk IDs to include in the metadata.               \
-        \        |\n\n## Response\n\n- **200**: Metadata retrieved successfully  \n\
-        \    - Without `chunk_ids`: Returns metadata grouped by filename, tag, and\
-        \ level  \n      `{filename: {tag_id: {chunk_level: {chunk_id: metadata},\
-        \ file_level: metadata}}}`\n    - With `chunk_ids`: Returns metadata by chunk\
-        \ ID  \n      `{chunk_id: {metadata}}`\n- **500**: Internal Server Error\n\
-        \n## Example\n\n```json\n{\n  \"data_connector_name\": \"my-connector\",\n\
-        \  \"dataslice_id\": \"abc123\",\n  \"tag_names\": [\"category\", \"date\"\
-        ],\n  \"include_chunk_level\": true,\n  \"file_names\": [\"document1.pdf\"\
-        , \"document2.pdf\"]\n}\n```"
-      operationId: list_metadata_route_metadata_list_post
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ListMetadataRequest'
-        required: true
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListMetadataResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          metadata = client.metadata.list(\n    data_connector_name=\"data_connector_name\"\
-          ,\n)\nprint(metadata.metadata)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst metadata = await\
-          \ client.metadata.list({ data_connector_name: 'data_connector_name' });\n\
-          \nconsole.log(metadata.metadata);"
-  /metadata/list_paginated:
-    post:
-      tags:
-      - Metadata
+      - Data Connectors
       summary: List Paginated
-      description: "Get paginated filtered metadata based on conditions.\n\n## Request\
-        \ Body\n\n| Field                 | Type                  | Description  \
-        \                                                                |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
-        | `data_connector_name` | `str`                 | Name of the data connector\
-        \ (vector database profile).                        |\n| `dataslice_id`  \
-        \      | `Optional[str]`       | ID of the dataslice to get files from.  \
-        \                                     |\n| `tag_names`           | `Optional[List[str]]`\
-        \ | List of tag names to include in the metadata.                        \
-        \        |\n| `include_chunk_level` | `Optional[bool]`      | Whether to include\
-        \ chunk-level metadata. Default: `true`                     |\n| `offset`\
-        \              | `Optional[int]`       | Pagination offset to start from.\
-        \ Default: `0`                                |\n| `limit`               |\
-        \ `Optional[int]`       | Maximum number of metadata items to return. Default:\
-        \ `50`                    |\n\n## Response\n\n- **200**: Metadata retrieved\
-        \ successfully  \n    - Returns: `{ \"metadata\": Deasy_Metadata, \"next_offset\"\
-        : Optional[int] }`\n- **500**: Internal Server Error\n\n## Example\n\n```json\n\
-        {\n  \"data_connector_name\": \"my-connector\",\n  \"dataslice_id\": \"abc123\"\
-        ,\n  \"tag_names\": [\"category\", \"date\"],\n  \"include_chunk_level\":\
-        \ true,\n  \"offset\": 0,\n  \"limit\": 50\n}\n```"
-      operationId: list_paginated_metadata_route_metadata_list_paginated_post
+      description: Retrieve a paginated list of files/nodes from the vector database
+        - supports shared connections
+      operationId: list_paginated_data_list_paginated_post
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ListPaginatedMetadataRequest'
+              $ref: '#/components/schemas/ListPaginatedRequest'
         required: true
       responses:
         '200':
@@ -1476,7 +906,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListPaginatedMetadataResponse'
+                $ref: '#/components/schemas/ListPaginatedResponse'
         '403':
           description: Missing token
           content:
@@ -1489,6 +919,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -1502,53 +938,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
           \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
           ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
           UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          response = client.metadata.list_paginated(\n    data_connector_name=\"data_connector_name\"\
-          ,\n)\nprint(response.metadata)"
+          response = client.data_source.list_ingested_data_paginated(\n    data_connector_name=\"\
+          data_connector_name\",\n)\nprint(response.entities)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.metadata.listPaginated({\n  data_connector_name: 'data_connector_name',\n\
-          });\n\nconsole.log(response.metadata);"
-  /metadata/delete:
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.listIngestedDataPaginated({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(response.entities);"
+  /data/document_text:
     post:
       tags:
-      - Metadata
-      summary: Delete
-      description: "Delete metadata for specified files, tags, and/or conditions.\n\
-        \n## Request Body\n\n| Field                 | Type                | Description\
-        \                                                                  |\n|-----------------------|---------------------|------------------------------------------------------------------------------|\n\
-        | `data_connector_name` | `str`               | Name of the data connector\
-        \ (vector database profile) to delete metadata from.|\n| `file_names`    \
-        \      | `Optional[List[str]]` | List of file names to delete metadata for.\
-        \                                  |\n| `tags`                | `Optional[List[str]]`\
-        \ | List of tags to filter which metadata to delete.                     \
-        \       |\n| `conditions`          | `Optional[Condition]` | Additional conditions\
-        \ to filter which metadata to delete.                   |\n\n## Response\n\
-        \n- **200**: Metadata deleted successfully  \n    - Returns: `{ \"chunk_deleted_count\"\
-        : int, \"file_deleted_count\": int }`\n- **500**: Internal Server Error\n\n\
-        ## Example\n\n```json\n{\n  \"data_connector_name\": \"my-connector\",\n \
-        \ \"file_names\": [\"document1.pdf\", \"document2.pdf\"],\n  \"tags\": [\"\
-        archived\", \"old\"]\n}\n```"
-      operationId: delete_metadata_route_metadata_delete_post
+      - Data Connectors
+      summary: Get Document Text
+      description: Retrieve the raw text content for specified documents from the
+        vector database
+      operationId: get_document_text_data_document_text_post
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeleteMetadataRequest'
+              $ref: '#/components/schemas/DocumentTextRequest'
         required: true
       responses:
         '200':
@@ -1556,7 +977,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DeleteMetadataResponse'
+                $ref: '#/components/schemas/DocumentTextResponse'
         '403':
           description: Missing token
           content:
@@ -1569,6 +990,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -1582,45 +1009,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
           \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
           ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
           UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          metadata = client.metadata.delete(\n    data_connector_name=\"data_connector_name\"\
-          ,\n)\nprint(metadata.chunk_deleted_count)"
+          response = client.data_source.document_text(\n    data_connector_name=\"\
+          data_connector_name\",\n    file_names=[\"string\"],\n)\nprint(response.file_to_nodes_to_text)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst metadata = await\
-          \ client.metadata.delete({ data_connector_name: 'data_connector_name' });\n\
-          \nconsole.log(metadata.chunk_deleted_count);"
-  /progress_tracker/task_status:
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.documentText({\n\
+          \  data_connector_name: 'data_connector_name',\n  file_names: ['string'],\n\
+          });\n\nconsole.log(response.file_to_nodes_to_text);"
+  /get_ocr_page_text:
     post:
       tags:
-      - Task Tracking
-      summary: Get Status
-      description: "Get the status of a task by job ID.\n\n## Request Body\n\n| Field\
-        \    | Type  | Description                                      |\n|----------|-------|--------------------------------------------------|\n\
-        | `job_id` | `str` | The unique identifier for the job to check.      |\n\n\
-        ## Response\n\n- **200**: Task status retrieved successfully  \n    - Returns:\
-        \ `{ \"percent_complete\": float, \"tags_created\": Optional[int], \"status\"\
-        : str }`\n- **404**: Job ID not found\n\n## Example\n\n```json\n{\n  \"job_id\"\
-        : \"abc123-def456-ghi789\"\n}\n```"
-      operationId: get_task_status_route_progress_tracker_task_status_post
+      - Data Connectors
+      summary: Get Ocr Page Text
+      operationId: get_ocr_page_text_get_ocr_page_text_post
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TaskStatusRequest'
+              $ref: '#/components/schemas/GetOCRPageTextRequest'
         required: true
       responses:
         '200':
@@ -1628,7 +1047,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TaskStatusResponse'
+                $ref: '#/components/schemas/GetOCRPageTextResponse'
         '403':
           description: Missing token
           content:
@@ -1641,6 +1060,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -1654,62 +1079,38 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
           \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
           ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
           UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          response = client.task_status.get_status(\n    job_id=\"job_id\",\n)\nprint(response.percent_complete)"
+          response = client.data_source.get_ocr_page_text(\n    data_connector_name=\"\
+          data_connector_name\",\n    file_name=\"file_name\",\n)\nprint(response.page_number)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.taskStatus.getStatus({ job_id: 'job_id' });\n\nconsole.log(response.percent_complete);"
-  /dataslice/create:
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.getOcrPageText({\n\
+          \  data_connector_name: 'data_connector_name',\n  file_name: 'file_name',\n\
+          });\n\nconsole.log(response.page_number);"
+  /sharepoint/list_sites:
     post:
       tags:
-      - Data Slices
-      summary: Create
-      description: "Create a new data slice based on specified conditions.\n\n## Request\
-        \ Body\n\n| Field             | Type           | Description             \
-        \                                                   |\n|-------------------|----------------|----------------------------------------------------------------------------|\n\
-        | `dataslice_name`  | `str`          | The name to assign to the newly created\
-        \ data slice.                        |\n| `condition`       | `Optional[List[Dict]]`\
-        \ | (Legacy) List of file qualifying conditions.                         |\n\
-        | `condition_new`   | `Optional[Any]` | New format: advanced file qualifying\
-        \ conditions.                           |\n| `description`     | `Optional[str]`\
-        \ | Description of the data slice.                                       \
-        \      |\n| `status`          | `str`          | The status of the data slice\
-        \ (e.g., active).                               |\n| `data_points`     | `Optional[int]`\
-        \ | Number of data points in the data slice.                             \
-        \      |\n| `latest_taxonomy`    | `Optional[Dict]` | Most recent taxonomy\
-        \ reference/metadata.                                      |\n| `taxonomy_id`\
-        \        | `Optional[str]` | ID of the related taxonomy, if applicable.  \
-        \                                  |\n| `data_connector_name` | `str`    \
-        \  | Name of the data connector (vector database profile).               \
-        \       |\n| `parent_dataslice_id` | `Optional[str]` | (Optional) Parent data\
-        \ slice ID, for lineage.                        |\n\n## Response\n\n- **201**:\
-        \ Data slice created successfully  \n    - Returns: `{ \"dataslice_id\": \"\
-        <uuid>\" }`\n- **500**: Internal Server Error.\n\n## Example\n\n```json\n\
-        {\n  \"dataslice_name\": \"Customer Purchases Q2\",\n  \"condition\": [\n\
-        \    { \"field\": \"created_date\", \"op\": \"gte\", \"value\": \"2024-04-01\"\
-        \ }\n  ],\n  \"description\": \"Purchase data from Q2 2024\",\n  \"status\"\
-        : \"active\",\n  \"data_points\": 4000,\n  \"data_connector_name\": \"prod-warehouse\"\
-        \n}\n```"
-      operationId: create_dataslice_route_dataslice_create_post
+      - Data Connectors
+      summary: List Sharepoint Sites
+      description: List all SharePoint sites in the tenant.
+      operationId: list_sharepoint_sites_sharepoint_list_sites_post
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/CreateDatasliceRequest'
+              $ref: '#/components/schemas/ListSharepointSitesRequest'
         required: true
       responses:
         '200':
@@ -1717,7 +1118,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateDatasliceResponse'
+                $ref: '#/components/schemas/ListSharepointSitesResponse'
         '403':
           description: Missing token
           content:
@@ -1726,19 +1127,6 @@ paths:
                 $ref: '#/components/schemas/HTTPError'
         '404':
           description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
           content:
             application/json:
               schema:
@@ -1749,54 +1137,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          data_slice = client.data_slice.create(\n    data_connector_name=\"data_connector_name\"\
-          ,\n    dataslice_name=\"dataslice_name\",\n)\nprint(data_slice.dataslice_id)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst dataSlice = await\
-          \ client.dataSlice.create({\n  data_connector_name: 'data_connector_name',\n\
-          \  dataslice_name: 'dataslice_name',\n});\n\nconsole.log(dataSlice.dataslice_id);"
-  /dataslice/list:
-    get:
-      tags:
-      - Data Slices
-      summary: List
-      description: "Retrieve all data slices associated with the currently authenticated\
-        \ user.\n\n### Response\n\nReturns a JSON object containing a list of dataslices:\n\
-        \n```json\n{\n  \"dataslices\": [\n    {\n      \"dataslice_id\": \"string\"\
-        ,\n      \"dataslice_name\": \"string\",\n      \"description\": \"string\"\
-        ,\n      \"status\": \"active\",\n      \"data_points\": 123,\n      \"latest_taxonomy\"\
-        : { /* taxonomy details */ },\n      \"taxonomy_id\": \"string\",\n      \"\
-        data_connector_name\": \"string\",\n      \"parent_dataslice_id\": \"string\
-        \ or null\"\n    },\n    ...\n  ]\n}\n```"
-      operationId: list_dataslices_route_dataslice_list_get
-      responses:
-        '200':
-          description: A list of dataslices the user can access.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ListDataslicesResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
         '429':
           description: Too many requests
           content:
@@ -1810,130 +1150,47 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
           \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
           ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
           UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          data_slices = client.data_slice.list()\nprint(data_slices.dataslices)"
+          response = client.data_source.list_sharepoint_sites(\n    client_id=\"client_id\"\
+          ,\n    client_secret=\"client_secret\",\n    tenant_id=\"tenant_id\",\n\
+          )\nprint(response.sites)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst dataSlices = await\
-          \ client.dataSlice.list();\n\nconsole.log(dataSlices.dataslices);"
-  /dataslice/delete:
-    delete:
-      tags:
-      - Data Slices
-      summary: Delete
-      description: "Delete a single data slice by its unique identifier.\n\n## Request\
-        \ Body\n\n| Field             | Type           | Description             \
-        \                                                   |\n|-------------------|----------------|----------------------------------------------------------------------------|\n\
-        | `dataslice_id`    | `str`        | The unique identifier of the data slice\
-        \ to delete.                        |\n\n### Response\n\nReturns a confirmation\
-        \ message of the successful deletion and any associated data.\n\n```json\n\
-        {\n  \"message\": \"Data slice deleted successfully\",\n  \"data\": {\n  \
-        \  // Details of deletion outcome\n  }\n}\n```"
-      operationId: delete_dataslice_route_dataslice_delete_delete
-      parameters:
-      - name: dataslice_id
-        in: query
-        required: true
-        schema:
-          type: string
-          title: Dataslice Id
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DeleteDatasliceResponse'
-        '403':
-          description: Missing token
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '404':
-          description: Resource not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '429':
-          description: Too many requests
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '500':
-          description: Internal Server Error. An unexpected error occurred while processing
-            the request.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-      x-codeSamples:
-      - lang: Python
-        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
-          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
-          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
-          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          data_slice = client.data_slice.delete(\n    dataslice_id=\"dataslice_id\"\
-          ,\n)\nprint(data_slice.data)"
-      - lang: JavaScript
-        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst dataSlice = await\
-          \ client.dataSlice.delete({ dataslice_id: 'dataslice_id' });\n\nconsole.log(dataSlice.data);"
-  /dataslice/export/metadata:
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.listSharepointSites({\n\
+          \  client_id: 'client_id',\n  client_secret: 'client_secret',\n  tenant_id:\
+          \ 'tenant_id',\n});\n\nconsole.log(response.sites);"
+  /onedrive/list_sites:
     post:
       tags:
-      - Data Slices
-      summary: Export
-      description: "Export metadata for a specific data slice or the entire data connector,\
-        \ in JSON or CSV format.\n\n## Request Body\n\n| Field                   \
-        \   | Type                  | Description                                \
-        \                                        |\n|----------------------------|-----------------------|------------------------------------------------------------------------------------|\n\
-        | `data_connector_name`      | `str`                 | Name of the data connector\
-        \ to export metadata from.                                |\n| `dataslice_id`\
-        \             | `Optional[str]`       | ID of the dataslice to export metadata\
-        \ from. If omitted, all data is included.     |\n| `export_file_level`   \
-        \     | `bool`                | `True` for file-level export, `False` for\
-        \ chunk-level export.                      |\n| `export_format`          \
-        \  | `Optional[ExportFormat]` | Desired export format: `json` or `csv` (e.g.,\
-        \ `\"json\"`, `\"csv\"`).               |\n| `selected_metadata_fields` |\
-        \ `Optional[List[str]]` | List of metadata fields to include in the export.\
-        \                                  |\n\n## Response\n\n- **200**: Metadata\
-        \ exported successfully  \n    - Returns: A streaming file response containing\
-        \ the exported metadata in the requested format.\n- **500**: Internal Server\
-        \ Error\n\n## Example\n\n```json\n{\n  \"data_connector_name\": \"example-connector\"\
-        ,\n  \"dataslice_id\": \"abc123\",\n  \"export_file_level\": true,\n  \"export_format\"\
-        : \"json\",\n  \"selected_metadata_fields\": [\"field1\", \"field2\"]\n}\n\
-        ```"
-      operationId: export_data_slice_dataslice_export_metadata_post
+      - Data Connectors
+      summary: List Onedrive Sites
+      description: List all OneDrive sites in the tenant (same Graph API as SharePoint).
+      operationId: list_onedrive_sites_onedrive_list_sites_post
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ExportDatasliceMetadataRequest'
+              $ref: '#/components/schemas/ListOnedriveSitesRequest'
         required: true
       responses:
         '200':
           description: Successful Response
           content:
             application/json:
-              schema: {}
+              schema:
+                $ref: '#/components/schemas/ListOnedriveSitesResponse'
         '403':
           description: Missing token
           content:
@@ -1946,6 +1203,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -1959,27 +1222,99 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
           \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
           ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
           UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
-          response = client.data_slice.export(\n    data_connector_name=\"data_connector_name\"\
-          ,\n)\nprint(response)"
+          response = client.data_source.list_onedrive_sites(\n    client_id=\"client_id\"\
+          ,\n    client_secret=\"client_secret\",\n    tenant_id=\"tenant_id\",\n\
+          )\nprint(response.sites)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.dataSlice.export({ data_connector_name: 'data_connector_name' });\n\
-          \nconsole.log(response);"
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.listOnedriveSites({\n\
+          \  client_id: 'client_id',\n  client_secret: 'client_secret',\n  tenant_id:\
+          \ 'tenant_id',\n});\n\nconsole.log(response.sites);"
+  /s3/list_buckets:
+    post:
+      tags:
+      - Data Connectors
+      summary: List S3 Buckets
+      description: List all S3 buckets accessible with the provided credentials.
+      operationId: list_s3_buckets_s3_list_buckets_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListS3BucketsRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListS3BucketsResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_source.list_s3_buckets(\n    aws_access_key_id=\"\
+          aws_access_key_id\",\n    aws_secret_access_key=\"aws_secret_access_key\"\
+          ,\n)\nprint(response.buckets)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSource.listS3Buckets({\n\
+          \  aws_access_key_id: 'aws_access_key_id',\n  aws_secret_access_key: 'aws_secret_access_key',\n\
+          });\n\nconsole.log(response.buckets);"
   /destination/create:
     post:
       tags:
@@ -2022,6 +1357,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -2035,12 +1376,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -2051,18 +1390,19 @@ paths:
           \        \"client_id\": \"client_id\",\n        \"client_secret\": \"client_secret\"\
           ,\n        \"documents_library_folder_name\": \"documents_library_folder_name\"\
           ,\n        \"name\": \"name\",\n        \"sharepoint_site_name\": \"sharepoint_site_name\"\
-          ,\n        \"tenant_id\": \"tenant_id\",\n    },\n    connector_name=\"\
-          connector_name\",\n)\nprint(connector_response.profile_id)"
+          ,\n        \"tenant_id\": \"tenant_id\",\n        \"type\": \"SharepointNodeDestinationManager\"\
+          ,\n    },\n    connector_name=\"connector_name\",\n)\nprint(connector_response.profile_id)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst connectorResponse\
-          \ = await client.destination.create({\n  connector_body: {\n    client_id:\
-          \ 'client_id',\n    client_secret: 'client_secret',\n    documents_library_folder_name:\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst connectorResponse = await\
+          \ client.destination.create({\n  connector_body: {\n    client_id: 'client_id',\n\
+          \    client_secret: 'client_secret',\n    documents_library_folder_name:\
           \ 'documents_library_folder_name',\n    name: 'name',\n    sharepoint_site_name:\
-          \ 'sharepoint_site_name',\n    tenant_id: 'tenant_id',\n  },\n  connector_name:\
-          \ 'connector_name',\n});\n\nconsole.log(connectorResponse.profile_id);"
+          \ 'sharepoint_site_name',\n    tenant_id: 'tenant_id',\n    type: 'SharepointNodeDestinationManager',\n\
+          \  },\n  connector_name: 'connector_name',\n});\n\nconsole.log(connectorResponse.profile_id);"
   /destination/list:
     post:
       tags:
@@ -2109,6 +1449,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -2118,10 +1462,11 @@ paths:
           destinations = client.destination.list()\nprint(destinations.connectors)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst destinations =\
-          \ await client.destination.list();\n\nconsole.log(destinations.connectors);"
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst destinations = await client.destination.list();\n\
+          \nconsole.log(destinations.connectors);"
   /destination/delete:
     post:
       tags:
@@ -2159,6 +1504,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -2172,12 +1523,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -2188,11 +1537,11 @@ paths:
           ,\n)\nprint(connector_response.profile_id)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst connectorResponse\
-          \ = await client.destination.delete({ connector_name: 'connector_name' });\n\
-          \nconsole.log(connectorResponse.profile_id);"
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst connectorResponse = await\
+          \ client.destination.delete({ connector_name: 'connector_name' });\n\nconsole.log(connectorResponse.profile_id);"
   /dataslice/export/metadata/destination:
     post:
       tags:
@@ -2270,6 +1619,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
         '429':
           description: Too many requests
           content:
@@ -2283,12 +1638,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPError'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
       x-codeSamples:
       - lang: Python
         source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
@@ -2298,16 +1651,4843 @@ paths:
           response = client.destination.export()\nprint(response.tracker_id)"
       - lang: JavaScript
         source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
-          \ = new UnstructuredClient({\n  username: process.env['UNSTRUCTURED_USERNAME'],\
-          \ // This is the default and can be omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'],\
-          \ // This is the default and can be omitted\n});\n\nconst response = await\
-          \ client.destination.export();\n\nconsole.log(response.tracker_id);"
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.destination.export();\n\
+          \nconsole.log(response.tracker_id);"
+  /tags/create:
+    post:
+      tags:
+      - Tags
+      summary: Create Tag Route
+      description: "Create a new tag\n\nAttributes:\n\n    tag_data: The tag data\
+        \ to create the tag with."
+      operationId: create_tag_route_tags_create_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateTagRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateTagResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          tag = client.tags.create(\n    tag_data={\n        \"name\": \"name\"\n\
+          \    },\n)\nprint(tag.tag)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst tag = await client.tags.create({\
+          \ tag_data: { name: 'name' } });\n\nconsole.log(tag.tag);"
+  /tags/upsert:
+    post:
+      tags:
+      - Tags
+      summary: Upsert
+      description: "Insert or update a tag definition.\n\n## Request Body\n\n| Field\
+        \      | Type            | Description                                   \
+        \   |\n|------------|-----------------|--------------------------------------------------|\n\
+        | `tag_data` | `Tag` | Tag data structure containing tag definition.    |\n\
+        \n## Response\n\n- **200**: Tag upserted successfully  \n    - Returns: `{\
+        \ \"tag_name\": str, \"tag\": Tag, \"available_values_added\": List[str] }`\n\
+        - **400**: Bad Request (e.g., invalid tag data)\n- **500**: Internal Server\
+        \ Error\n\n## Example\n\n```json\n{\n  \"tag_data\": {\n    \"name\": \"category\"\
+        ,\n    \"description\": \"Document category classification\",\n    \"type\"\
+        : \"select\",\n    \"available_values\": [\"invoice\", \"receipt\", \"contract\"\
+        ]\n  }\n}\n```"
+      operationId: upsert_tag_route_tags_upsert_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertTagRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpsertTagResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.upsert(\n    tag_data={\n        \"name\": \"name\"\
+          \n    },\n)\nprint(response.available_values_added)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.upsert({\
+          \ tag_data: { name: 'name' } });\n\nconsole.log(response.available_values_added);"
+  /tags/upsert_bulk:
+    post:
+      tags:
+      - Tags
+      summary: Bulk Upsert Tag
+      description: "Bulk upsert tags\n\nAttributes:\n\n    tag_data: The tag data\
+        \ to upsert the tag with."
+      operationId: bulk_upsert_tag_tags_upsert_bulk_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkUpsertTagRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkUpsertTagResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.upsert_bulk(\n    tag_data=[{\n        \"name\":\
+          \ \"name\"\n    }],\n)\nprint(response.available_values_added_by_tag)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.upsertBulk({\
+          \ tag_data: [{ name: 'name' }] });\n\nconsole.log(response.available_values_added_by_tag);"
+  /tags/update:
+    put:
+      tags:
+      - Tags
+      summary: Update Tag Route
+      description: "Update an existing tag\n\nAttributes:\n\n    tag_data: The tag\
+        \ data to update the tag with."
+      operationId: update_tag_route_tags_update_put
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateTagRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateTagResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          tag = client.tags.update(\n    tag_data={\n        \"name\": \"name\"\n\
+          \    },\n)\nprint(tag.tag)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst tag = await client.tags.update({\
+          \ tag_data: { name: 'name' } });\n\nconsole.log(tag.tag);"
+  /tags/list:
+    get:
+      tags:
+      - Tags
+      summary: List
+      description: "List all tags for the authenticated user.\n\n## Response\n\n-\
+        \ **200**: Tags retrieved successfully  \n    - Returns: `{ \"tags\": List[Tag]\
+        \ }`\n- **500**: Internal Server Error\n\n## Example Response\n\n```json\n\
+        {\n  \"tags\": [\n    {\n      \"name\": \"category\",\n      \"description\"\
+        : \"Document category\",\n      \"type\": \"select\",\n      \"available_values\"\
+        : [\"invoice\", \"receipt\"]\n    },\n    {\n      \"name\": \"date\",\n \
+        \     \"description\": \"Document date\",\n      \"type\": \"date\"\n    }\n\
+        \  ]\n}\n```"
+      operationId: list_tags_route_tags_list_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListTagsResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          tags = client.tags.list()\nprint(tags.tags)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst tags = await client.tags.list();\n\
+          \nconsole.log(tags.tags);"
+  /tags/delete:
+    delete:
+      tags:
+      - Tags
+      summary: Delete
+      description: "Delete a tag by name. Tag must not be in use by any graphs or\
+        \ dataslices.\n\n## Query Parameters\n\n| Parameter  | Type  | Description\
+        \                          |\n|------------|-------|--------------------------------------|\n\
+        | `tag_name` | `str` | Name of the tag to delete.           |\n\n## Response\n\
+        \n- **200**: Tag deleted successfully  \n    - Returns: `{ \"tag_name\": str\
+        \ }`\n- **500**: Internal Server Error (e.g., tag still in use)\n\n## Example\n\
+        \n```\nDELETE /tags/delete?tag_name=category\n```"
+      operationId: delete_tag_route_tags_delete_delete
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      parameters:
+      - name: tag_name
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Tag Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          tag_response = client.tags.delete(\n    tag_name=\"tag_name\",\n)\nprint(tag_response.tag_name)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst tagResponse = await client.tags.delete({\
+          \ tag_name: 'tag_name' });\n\nconsole.log(tagResponse.tag_name);"
+  /tags/default:
+    get:
+      tags:
+      - Tags
+      summary: Get Default Tags Route
+      description: Return the current OOB default tag definitions (name + available_values).
+      operationId: get_default_tags_route_tags_default_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.list_defaults()\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.listDefaults();\n\
+          \nconsole.log(response);"
+  /tags/sensitivity_default:
+    get:
+      tags:
+      - Tags
+      summary: Get Sensitivity Default Tags Route
+      description: Return the current OOB sensitivity tag definitions (name + available_values).
+      operationId: get_sensitivity_default_tags_route_tags_sensitivity_default_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.list_sensitivity_defaults()\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.listSensitivityDefaults();\n\
+          \nconsole.log(response);"
+  /tags/scores:
+    post:
+      tags:
+      - Tags
+      summary: Get Tag Scores
+      description: Get tag scores
+      operationId: get_tag_scores_tags_scores_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TagScoresRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagScoresResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.scores(\n    tag_names=[\"string\"],\n)\nprint(response.scores)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.scores({\
+          \ tag_names: ['string'] });\n\nconsole.log(response.scores);"
+  /tags/searchability_scores:
+    get:
+      tags:
+      - Tags
+      summary: Get Searchability Scores
+      description: "Get stored searchability scores for tags in a dataset context.\n\
+        \n## Query Parameters\n\n| Parameter            | Type           | Required\
+        \ | Description                                    |\n|---------------------|----------------|----------|------------------------------------------------|\n\
+        | `data_connector_name`| `str`          | Yes      | Name of the data connector/dataset\
+        \             |\n| `dataslice_id`      | `str`          | No       | Optional\
+        \ dataslice ID for filtered scores      |\n| `tag_names`         | `List[str]`\
+        \    | No       | Optional list of specific tag names            |\n\n## Response\n\
+        \nReturns a simple dictionary mapping tag names to their searchability scores:\n\
+        \n```json\n{\n  \"Invoice Number\": 0.85,\n  \"Date\": 0.92,\n  \"Vendor\"\
+        : 0.78\n}\n```\n\nFrontend can merge this with tag definitions client-side\
+        \ for optimal performance."
+      operationId: get_searchability_scores_tags_searchability_scores_get
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      parameters:
+      - name: data_connector_name
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Data Connector Name
+      - name: dataslice_id
+        in: query
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+      - name: tag_names
+        in: query
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+          title: Tag Names
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: number
+                title: Response Get Searchability Scores Tags Searchability Scores
+                  Get
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.get_searchability_scores(\n    data_connector_name=\"\
+          data_connector_name\",\n)\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.getSearchabilityScores({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(response);"
+  /tags/update_searchability_scores:
+    post:
+      tags:
+      - Tags
+      summary: Update Tag Searchability Scores
+      description: Get tag searchability scores
+      operationId: update_tag_searchability_scores_tags_update_searchability_scores_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TagSearchabilityScoresRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TagSearchabilityScoresResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.update_searchability_scores()\nprint(response.scores)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.updateSearchabilityScores();\n\
+          \nconsole.log(response.scores);"
+  /suggest_regex:
+    post:
+      tags:
+      - Tags
+      summary: Suggest Patterns
+      description: "Generate a regex pattern based on a natural language description\
+        \ using AI.\n\n## Request Body\n\n| Field              | Type           |\
+        \ Description                                                            \
+        \                  |\n|--------------------|----------------|------------------------------------------------------------------------------------------|\n\
+        | `description`      | `str`          | Natural language description of what\
+        \ to match (e.g., \"phone numbers in format (XXX) XXX-XXXX\"). |\n| `examples`\
+        \         | `List[str]`    | Optional. List of example strings that should\
+        \ match the pattern.                         |\n\n## Response\n\n- **200**:\
+        \ Regex pattern generated successfully  \n    - Returns: `{ \"regex\": str\
+        \ }`\n- **400**: Bad Request (e.g., invalid request data)\n- **500**: Internal\
+        \ Server Error\n\n## Example\n\n```json\n{\n  \"description\": \"phone numbers\
+        \ in format (XXX) XXX-XXXX\",\n  \"examples\": [\n    \"(123) 456-7890\",\n\
+        \    \"(555) 123-4567\"\n  ]\n}\n```\n\n## Example Response\n\n```json\n{\n\
+        \  \"regex\": \"\\(\\d{3}\\) \\d{3}-\\d{4}\",\n}\n```"
+      operationId: suggest_patterns_route_suggest_regex_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SuggestRegexRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuggestRegexResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.pattern.suggest_patterns(\n    pattern_description=\"\
+          pattern_description\",\n    tag_data={\n        \"name\": \"name\"\n   \
+          \ },\n)\nprint(response.confidence_score)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.pattern.suggestPatterns({\n\
+          \  pattern_description: 'pattern_description',\n  tag_data: { name: 'name'\
+          \ },\n});\n\nconsole.log(response.confidence_score);"
+  /suggest_description:
+    post:
+      tags:
+      - Tags
+      summary: Suggest Description
+      description: "Suggest a description for a tag based on context and vector DB\
+        \ content\n\nAttributes:\n\n    data_connector_name: The name of the vdb profile\
+        \ to include in the dataslice.\n    tag_name: The name of the tag to suggest\
+        \ a description for.\n    context: The context to suggest a description for\
+        \ the tag.\n    current_description: The current description of the tag.\n\
+        \    available_values: The available values for the tag."
+      operationId: suggest_description_suggest_description_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SuggestDescriptionRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuggestDescriptionResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.suggest_description(\n    data_connector_name=\"\
+          data_connector_name\",\n    tag_name=\"tag_name\",\n)\nprint(response.suggestion)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.suggestDescription({\n\
+          \  data_connector_name: 'data_connector_name',\n  tag_name: 'tag_name',\n\
+          });\n\nconsole.log(response.suggestion);"
+  /suggest_strategy:
+    post:
+      tags:
+      - Tags
+      summary: Suggest Extraction Strategy
+      description: "Determine the optimal extraction strategy for a tag based on its\
+        \ name and description.\n\nReturns either 'LLM' (AI-based extraction) or 'REGEX'\
+        \ (pattern-based extraction).\n\n## When to use each strategy\n\n**REGEX**\
+        \ - Use when:\n- Values have consistent, predictable formatting (dates, IDs,\
+        \ phone numbers, emails)\n- Known exact patterns that repeat predictably\n\
+        - Structured data with fixed delimiters or formats\n\n**LLM** - Use when:\n\
+        - Semantic understanding is required\n- Values depend on interpreting content,\
+        \ not matching formats\n- Classifications, categorizations, sentiment, summaries\n\
+        \n## Request Body\n\n| Field              | Type           | Description \
+        \                                   |\n|--------------------|----------------|------------------------------------------------|\n\
+        | `tag_name`         | `str`          | The name of the tag              \
+        \              |\n| `tag_description`  | `str`          | Description of what\
+        \ the tag captures           |\n| `available_values` | `List[str]`    | Optional.\
+        \ Example values to help determine strategy |\n\n## Response\n\n- **200**:\
+        \ Strategy recommendation returned successfully\n    - Returns: `{ \"strategy\"\
+        : \"LLM\" }` or `{ \"strategy\": \"REGEX\" }`\n- **500**: Internal Server\
+        \ Error"
+      operationId: suggest_strategy_suggest_strategy_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SuggestStrategyRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuggestStrategyResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.suggest_strategy(\n    tag_description=\"tag_description\"\
+          ,\n    tag_name=\"tag_name\",\n)\nprint(response.strategy)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.suggestStrategy({\n\
+          \  tag_description: 'tag_description',\n  tag_name: 'tag_name',\n});\n\n\
+          console.log(response.strategy);"
+  /generate_test_cases:
+    post:
+      tags:
+      - Tags
+      summary: Generate Test Cases
+      description: "Generate test cases for regex pattern validation.\n\nCreates both\
+        \ positive (should match) and negative (should NOT match) test cases\nto help\
+        \ users validate their regex patterns.\n\nAttributes:\n    pattern_descriptions:\
+        \ List of descriptions of what patterns should match.\n    existing_patterns:\
+        \ Optional existing regex patterns to test against."
+      operationId: generate_test_cases_generate_test_cases_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateTestCasesRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateTestCasesResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.pattern.generate_test_cases(\n    pattern_descriptions=[\"\
+          string\"],\n)\nprint(response.test_cases)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.pattern.generateTestCases({\
+          \ pattern_descriptions: ['string'] });\n\nconsole.log(response.test_cases);"
+  /evaluate_test_cases:
+    post:
+      tags:
+      - Tags
+      summary: Evaluate Test Cases
+      description: "Evaluate test cases against multiple regex patterns.\n\nThis route\
+        \ allows users to validate regex patterns using Python's regex engine,\nwhich\
+        \ is important because Python regex and JavaScript regex have differences.\n\
+        Tests each case against all patterns and returns whether it matched.\n\nA\
+        \ test case is considered to match if ANY of the provided patterns match it.\n\
+        \nArgs:\n    patterns: List of regex patterns to test (with description and\
+        \ optional output_value)\n    test_cases: List of test cases with text, expected\
+        \ match behavior, and category\n\nReturns:\n    EvaluateTestCasesResponse\
+        \ with evaluated test cases showing actual_match results"
+      operationId: evaluate_test_cases_evaluate_test_cases_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvaluateTestCasesRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateTestCasesResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.tags.pattern.evaluate_test_cases(\n    patterns=[{\n \
+          \       \"pattern\": \"pattern\"\n    }],\n    test_cases=[{\n        \"\
+          category\": \"category\",\n        \"should_match\": True,\n        \"text\"\
+          : \"text\",\n    }],\n)\nprint(response.evaluated_test_cases)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.tags.pattern.evaluateTestCases({\n\
+          \  patterns: [{ pattern: 'pattern' }],\n  test_cases: [\n    {\n      category:\
+          \ 'category',\n      should_match: true,\n      text: 'text',\n    },\n\
+          \  ],\n});\n\nconsole.log(response.evaluated_test_cases);"
+  /taxonomy/upsert:
+    post:
+      tags:
+      - Taxonomies
+      summary: Upsert
+      description: "Insert or update a taxonomy (schema/hierarchy) in the database.\n\
+        \n## Request Body\n\n| Field                  | Type             | Description\
+        \                                                          |\n|------------------------|------------------|----------------------------------------------------------------------|\n\
+        | `taxonomy_name`        | `str`            | Name of the taxonomy to upsert.\
+        \                                      |\n| `new_taxonomy_name`    | `Optional[str]`\
+        \  | New name for the taxonomy (when updating).                          \
+        \ |\n| `taxonomy_description` | `Optional[str]`  | Description of the taxonomy.\
+        \                                         |\n| `taxonomy_data`        | `Optional[Dict]`\
+        \ | The taxonomy/hierarchy data structure.                               |\n\
+        \n## Response\n\n- **200**: Taxonomy upserted successfully  \n    - Returns:\
+        \ `{ \"taxonomy_name\": str }`\n- **500**: Internal Server Error\n\n## Example\n\
+        \n```json\n{\n  \"taxonomy_name\": \"document-categories\",\n  \"taxonomy_description\"\
+        : \"Main document classification taxonomy\",\n  \"taxonomy_data\": {\n   \
+        \ \"invoice\": [\"purchase_invoice\", \"sales_invoice\"],\n    \"receipt\"\
+        : [\"expense_receipt\", \"payment_receipt\"]\n  }\n}\n```"
+      operationId: upsert_taxonomy_route_taxonomy_upsert_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertTaxonomyRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxonomyOperationResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          taxonomy_operation_response = client.taxonomy.upsert(\n    taxonomy_name=\"\
+          taxonomy_name\",\n)\nprint(taxonomy_operation_response.taxonomy_name)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst taxonomyOperationResponse\
+          \ = await client.taxonomy.upsert({ taxonomy_name: 'taxonomy_name' });\n\n\
+          console.log(taxonomyOperationResponse.taxonomy_name);"
+  /taxonomy/list:
+    post:
+      tags:
+      - Taxonomies
+      summary: List
+      description: "List all taxonomies (schemas/hierarchies) for the authenticated\
+        \ user.\n\n## Request Body\n\n| Field          | Type                  | Description\
+        \                                                          |\n|----------------|-----------------------|----------------------------------------------------------------------|\n\
+        | `taxonomy_ids` | `Optional[List[str]]` | List of specific taxonomy IDs to\
+        \ retrieve. If omitted, returns all taxonomies. |\n\n## Response\n\n- **200**:\
+        \ Taxonomies retrieved successfully  \n    - Returns: `{ \"taxonomies\": List[DeasyTaxonomy]\
+        \ }`\n- **500**: Internal Server Error\n\n## Example\n\n```json\n{\n  \"taxonomy_ids\"\
+        : [\"document-categories\", \"sentiment-types\"]\n}\n```"
+      operationId: list_taxonomies_route_taxonomy_list_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListTaxonomiesRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListTaxonomiesResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          taxonomies = client.taxonomy.list()\nprint(taxonomies.taxonomies)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst taxonomies = await client.taxonomy.list();\n\
+          \nconsole.log(taxonomies.taxonomies);"
+  /taxonomy/delete:
+    delete:
+      tags:
+      - Taxonomies
+      summary: Delete
+      description: "Delete a taxonomy (schema/hierarchy) by name.\n\n## Query Parameters\n\
+        \n| Parameter       | Type  | Description                             |\n\
+        |-----------------|-------|-----------------------------------------|\n| `taxonomy_name`\
+        \ | `str` | Name of the taxonomy to delete.         |\n\n## Response\n\n-\
+        \ **200**: Taxonomy deleted successfully  \n    - Returns: `{ \"taxonomy_name\"\
+        : str }`\n- **500**: Internal Server Error\n\n## Example\n\n```\nDELETE /taxonomy/delete?taxonomy_name=document-categories\n\
+        ```"
+      operationId: delete_taxonomy_route_taxonomy_delete_delete
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      parameters:
+      - name: taxonomy_name
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Taxonomy Name
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaxonomyOperationResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          taxonomy_operation_response = client.taxonomy.delete(\n    taxonomy_name=\"\
+          taxonomy_name\",\n)\nprint(taxonomy_operation_response.taxonomy_name)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst taxonomyOperationResponse\
+          \ = await client.taxonomy.delete({ taxonomy_name: 'taxonomy_name' });\n\n\
+          console.log(taxonomyOperationResponse.taxonomy_name);"
+  /taxonomy/generate_from_context:
+    post:
+      tags:
+      - Taxonomies
+      summary: Generate from Context
+      description: "Generate a taxonomy structure from user-provided context using\
+        \ AI.\n\nThis endpoint allows users to describe their data and use case, and\
+        \ the system will\ngenerate an appropriate taxonomy structure (hierarchical\
+        \ or flat) without requiring\nactual data files.\n\n## Request Body\n\n| Field\
+        \              | Type             | Description                          \
+        \                                |\n|--------------------|------------------|----------------------------------------------------------------------|\n\
+        | `user_context`     | `str`            | Free-form description of the data\
+        \ and intended use                   |\n| `industry`         | `Optional[str]`\
+        \  | Industry context (e.g., \"Healthcare\", \"Finance\", \"Legal\")     \
+        \       |\n| `data_type`        | `Optional[str]`  | Type of data (e.g., \"\
+        documents\", \"customer records\")                 |\n| `use_case`       \
+        \  | `Optional[str]`  | Specific use case description                    \
+        \                    |\n| `taxonomy_type`    | `str`            | Type of\
+        \ taxonomy: \"hierarchical\" or \"flat\". Default: \"hierarchical\"  |\n|\
+        \ `max_depth`        | `Optional[int]`  | Maximum depth for hierarchical taxonomies.\
+        \ Default: 3                |\n| `llm_profile_name` | `Optional[str]`  | LLM\
+        \ profile to use. Defaults to system default if not specified      |\n\n##\
+        \ Response\n\n- **200**: Taxonomy generated successfully  \n    - Returns:\
+        \ `{ \"taxonomy_data\": Dict, \"taxonomy_description\": str }`\n- **400**:\
+        \ Invalid request or LLM configuration error\n- **500**: Internal Server Error\n\
+        \n## Example\n\n```json\n{\n  \"user_context\": \"I have customer support\
+        \ tickets with priority levels, categories, and resolution status\",\n  \"\
+        industry\": \"Technology\",\n  \"data_type\": \"support tickets\",\n  \"use_case\"\
+        : \"categorize and analyze support requests\",\n  \"taxonomy_type\": \"hierarchical\"\
+        ,\n  \"max_depth\": 3\n}\n```"
+      operationId: generate_taxonomy_from_context_route_taxonomy_generate_from_context_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateTaxonomyFromContextRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateTaxonomyFromContextResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.taxonomy.generate_from_context(\n    user_context=\"user_context\"\
+          ,\n)\nprint(response.taxonomy_data)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.taxonomy.generateFromContext({\
+          \ user_context: 'user_context' });\n\nconsole.log(response.taxonomy_data);"
+  /suggest_schema:
+    post:
+      tags:
+      - Taxonomies
+      summary: Suggest
+      description: "Suggest a tag taxonomy based on file content and existing metadata.\n\
+        \n## Request Body\n\n| Field                   | Type                   |\
+        \ Description                                                            \
+        \      |\n|-------------------------|------------------------|------------------------------------------------------------------------------|\n\
+        | `data_connector_name`   | `str`                  | Name of the data connector\
+        \ (vector database profile) to use.                 |\n| `file_names`    \
+        \        | `Optional[List[str]]`  | List of specific files to analyze for\
+        \ the hierarchy suggestion.              |\n| `dataslice_id`          | `Optional[str]`\
+        \        | ID of a dataslice to pull files from for the suggestion.      \
+        \               |\n| `progress_tracking_id`  | `Optional[str]`        | Custom\
+        \ tracking ID for monitoring the suggestion progress.                   |\n\
+        | `taxonomy_name`           | `Optional[str]`        | Name for the suggested\
+        \ schema/taxonomy.                                      |\n| `current_tree`\
+        \          | `Optional[Dict]`       | Existing hierarchy tree to build upon.\
+        \                                       |\n| `condition`             | `Optional[Condition]`\
+        \  | Filtering condition to select specific files for analysis.          \
+        \         |\n| `node`                  | `Optional[GraphNode]`  | Node location\
+        \ in the existing hierarchy tree to build upon. Default: `{}`    |\n| `user_context`\
+        \          | `Optional[str]`        | User-provided context to guide the suggestion\
+        \ process.                       |\n| `context_level`         | `Optional[str]`\
+        \        | Level at which to analyze content: `file` or `chunk`. Default:\
+        \ `\"file\"`      |\n| `max_height`            | `Optional[int]`        |\
+        \ Maximum depth of the generated hierarchy tree. Default: `2`            \
+        \      |\n| `use_existing_tags`     | `Optional[bool]`       | Whether to\
+        \ incorporate existing tags in suggestions. Default: `false`        |\n| `use_extracted_tags`\
+        \    | `Optional[bool]`       | Whether to use previously extracted tags.\
+        \ Default: `false`                   |\n| `use_mix_llm_and_source`| `Optional[bool]`\
+        \       | Whether to mix LLM-generated and source-based tags. Default: `false`\
+        \         |\n\n## Response\n\n- **200**: Schema suggestion generated successfully\
+        \  \n    - Returns: `{ \"status_code\": int, \"message\": str, \"suggestion\"\
+        : Dict, \"suggested_tags\": Optional[Dict], \"node\": Optional[GraphNode],\
+        \ \"tag_not_found_rates\": Optional[Dict] }`\n- **500**: Internal Server Error\n\
+        \n## Example\n\n```json\n{\n  \"data_connector_name\": \"my-connector\",\n\
+        \  \"file_names\": [\"document1.pdf\", \"document2.pdf\"],\n  \"context_level\"\
+        : \"file\",\n  \"max_height\": 3,\n  \"use_existing_tags\": true,\n  \"user_context\"\
+        : \"Suggest categories for financial documents\"\n}\n```"
+      operationId: suggest_schema_route_suggest_schema_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MetadataSuggestionRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MetadataSuggestionResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.taxonomy.suggest(\n    data_connector_name=\"data_connector_name\"\
+          ,\n)\nprint(response.job_id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.taxonomy.suggest({\
+          \ data_connector_name: 'data_connector_name' });\n\nconsole.log(response.job_id);"
+  /classify:
+    post:
+      tags:
+      - Metadata
+      summary: Generate
+      description: "Classify specified files with the provided tags.\nTo run sensitivity\
+        \ detection, use tags with a strategy of SENSITIVITY or a group which includes\
+        \ the magic word \"Sensitivity\"\n\n## Request Body\n\n| Field           \
+        \      | Type                  | Description                             \
+        \                                     |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
+        | `data_connector_name` | `str`                 | Name of the data connector\
+        \ (vector database profile) to use for classification. |\n| `file_names` \
+        \         | `Optional[List[str]]` | Names of specific files to classify. \
+        \                                        |\n| `tag_names`           | `Optional[List[str]]`\
+        \ | Names of tags to use for classification (if `tag_datas` not provided).\
+        \       |\n| `tag_datas`           | `Optional[Dict]`      | Tag data to use\
+        \ for classification.                                          |\n| `overwrite`\
+        \           | `bool`                | Whether to overwrite existing tags.\
+        \ Default: `false`                         |\n| `job_id`              | `Optional[str]`\
+        \       | Custom job ID for tracking the classification task.            \
+        \              |\n| `soft_run`            | `bool`                | If `true`,\
+        \ classification will not save to Deasy and will return results. Default:\
+        \ `false` |\n| `hierarchy_name`      | `Optional[str]`       | Name of the\
+        \ hierarchy/taxonomy to use (if `hierarchy_data` not provided).       |\n\
+        | `hierarchy_data`      | `Optional[Dict]`      | Hierarchy/taxonomy data\
+        \ to use for classification. Default: `{}`                |\n| `dataslice_id`\
+        \        | `Optional[str]`       | ID of the dataslice to use for file filtering.\
+        \                               |\n\n## Response\n\n- **200**: Classification\
+        \ completed or job started successfully  \n    - Returns: `{ \"message\":\
+        \ str, \"job_id\": str, \"results\": Optional[Dict] }`\n- **500**: Internal\
+        \ Server Error\n\n## Example\n\n```json\n{\n  \"data_connector_name\": \"\
+        my-connector\",\n  \"file_names\": [\"document1.pdf\", \"document2.pdf\"],\n\
+        \  \"tag_names\": [\"category\", \"sentiment\"],\n  \"overwrite\": false,\n\
+        \  \"soft_run\": false\n}\n```"
+      operationId: generate_route_classify_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClassifyRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClassifyResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.generate.generate(\n    data_connector_name=\"\
+          data_connector_name\",\n)\nprint(response.message)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.generate.generate({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(response.message);"
+  /classify_bulk:
+    post:
+      tags:
+      - Metadata
+      summary: Generate Batch
+      description: "Classify all files in a data connector in batches with the provided\
+        \ tags. \nTo run sensitivity detection, use tags with a strategy of SENSITIVITY\
+        \ or a group which includes the magic word \"Sensitivity\"\n\n## Request Body\n\
+        \n| Field                 | Type                  | Description          \
+        \                                                        |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
+        | `data_connector_name` | `str`                 | Name of the data connector\
+        \ (vector database profile) to use for classification. |\n| `total_data_sets`\
+        \     | `Optional[int]`       | Total number of files to classify.       \
+        \                                    |\n| `tag_names`           | `Optional[List[str]]`\
+        \ | Names of tags to use for classification (if `tag_datas` not provided).\
+        \       |\n| `tag_datas`           | `Optional[Dict]`      | Tag data to use\
+        \ for classification.                                          |\n| `overwrite`\
+        \           | `bool`                | Whether to overwrite existing tags.\
+        \ Default: `false`                         |\n| `job_id`              | `Optional[str]`\
+        \       | Custom job ID for tracking the classification task.            \
+        \              |\n| `hierarchy_name`      | `Optional[str]`       | Name of\
+        \ the hierarchy/taxonomy to use (if `hierarchy_data` not provided).      \
+        \ |\n| `hierarchy_data`      | `Optional[Dict]`      | Hierarchy/taxonomy\
+        \ data to use for classification. Default: `{}`                |\n| `dataslice_id`\
+        \        | `Optional[str]`       | ID of the dataslice to use for file filtering.\
+        \                               |\n| `conditions`          | `Optional[Condition]`\
+        \ | Conditions to use for file filtering.                                \
+        \        |\n\n## Response\n\n- **200**: Classification job started successfully\
+        \  \n    - Returns: `{ \"message\": str, \"job_id\": str }`\n- **500**: Internal\
+        \ Server Error\n\n## Example\n\n```json\n{\n  \"data_connector_name\": \"\
+        my-connector\",\n  \"tag_names\": [\"category\", \"sentiment\"],\n  \"overwrite\"\
+        : false,\n  \"dataslice_id\": \"abc123\"\n}\n```"
+      operationId: generate_batch_route_classify_bulk_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClassifyBulkRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClassifyBulkResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.generate.generate_batch(\n    data_connector_name=\"\
+          data_connector_name\",\n)\nprint(response.message)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.generate.generateBatch({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(response.message);"
+  /metadata/upsert:
+    post:
+      tags:
+      - Metadata
+      summary: Upsert
+      description: "Insert or update metadata for files and tags.\n\n## Request Body\n\
+        \n| Field                 | Type                  | Description          \
+        \                                                        |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
+        | `data_connector_name` | `Optional[str]`       | Name of the data connector\
+        \ (vector database profile).                        |\n| `dataslice_id`  \
+        \      | `Optional[str]`       | ID of the dataslice to upsert metadata for.\
+        \                                  |\n| `metadata`            | `Deasy_Metadata`\
+        \      | Metadata to upsert in the form `{file_name: {tag_name: tag_value}}`.\
+        \         |\n\n## Response\n\n- **200**: Metadata upserted successfully  \n\
+        \    - Returns: `{ \"success\": bool }`\n- **500**: Internal Server Error\n\
+        \n## Example\n\n```json\n{\n  \"data_connector_name\": \"my-connector\",\n\
+        \  \"metadata\": {\n    \"document1.pdf\": {\n      \"category\": \"invoice\"\
+        ,\n      \"date\": \"2024-01-15\"\n    },\n    \"document2.pdf\": {\n    \
+        \  \"category\": \"receipt\",\n      \"status\": \"processed\"\n    }\n  }\n\
+        }\n```"
+      operationId: upsert_metadata_route_metadata_upsert_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertMetadataRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpsertMetadataResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.upsert(\n    metadata={\n        \"foo\": {\n\
+          \            \"foo\": {}\n        }\n    },\n)\nprint(response.success)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.upsert({\
+          \ metadata: { foo: { foo: {} } } });\n\nconsole.log(response.success);"
+  /metadata/list:
+    post:
+      tags:
+      - Metadata
+      summary: List
+      description: "Get filtered metadata based on conditions. Supports shared connections.\n\
+        \n## Request Body\n\n| Field                 | Type                  | Description\
+        \                                                                  |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
+        | `data_connector_name` | `str`                 | Name of the data connector\
+        \ (vector database profile).                        |\n| `dataslice_id`  \
+        \      | `Optional[str]`       | ID of the dataslice to get files from.  \
+        \                                     |\n| `tag_names`           | `Optional[List[str]]`\
+        \ | List of tag names to include in the metadata.                        \
+        \        |\n| `include_chunk_level` | `Optional[bool]`      | Whether to include\
+        \ chunk-level metadata. Default: `true`                     |\n| `file_names`\
+        \          | `Optional[List[str]]` | List of specific file names to include\
+        \ in the metadata.                      |\n| `chunk_ids`           | `Optional[List[str]]`\
+        \ | List of specific chunk IDs to include in the metadata.               \
+        \        |\n| `include_last_updated`| `Optional[bool]`      | Whether to include\
+        \ the last updated timestamp. Default: `false`              |\n\n## Response\n\
+        \n- **200**: Metadata retrieved successfully  \n    - Without `chunk_ids`:\
+        \ Returns metadata grouped by filename, tag, and level  \n      `{filename:\
+        \ {tag_id: {chunk_level: {chunk_id: metadata}, file_level: metadata}}}`\n\
+        \    - With `chunk_ids`: Returns metadata by chunk ID  \n      `{chunk_id:\
+        \ {metadata}}`\n- **500**: Internal Server Error\n\n## Example\n\n```json\n\
+        {\n  \"data_connector_name\": \"my-connector\",\n  \"dataslice_id\": \"abc123\"\
+        ,\n  \"tag_names\": [\"category\", \"date\"],\n  \"include_chunk_level\":\
+        \ true,\n  \"file_names\": [\"document1.pdf\", \"document2.pdf\"]\n}\n```"
+      operationId: list_metadata_route_metadata_list_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListMetadataRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListMetadataResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          metadata = client.metadata.list(\n    data_connector_name=\"data_connector_name\"\
+          ,\n)\nprint(metadata.metadata)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst metadata = await client.metadata.list({\
+          \ data_connector_name: 'data_connector_name' });\n\nconsole.log(metadata.metadata);"
+  /metadata/list_paginated:
+    post:
+      tags:
+      - Metadata
+      summary: List Paginated
+      description: "Get paginated filtered metadata based on conditions.\n\n## Request\
+        \ Body\n\n| Field                 | Type                  | Description  \
+        \                                                                |\n|-----------------------|-----------------------|------------------------------------------------------------------------------|\n\
+        | `data_connector_name` | `str`                 | Name of the data connector\
+        \ (vector database profile).                        |\n| `dataslice_id`  \
+        \      | `Optional[str]`       | ID of the dataslice to get files from.  \
+        \                                     |\n| `tag_names`           | `Optional[List[str]]`\
+        \ | List of tag names to include in the metadata.                        \
+        \        |\n| `include_chunk_level` | `Optional[bool]`      | Whether to include\
+        \ chunk-level metadata. Default: `true`                     |\n| `offset`\
+        \              | `Optional[int]`       | Pagination offset to start from.\
+        \ Default: `0`                                |\n| `limit`               |\
+        \ `Optional[int]`       | Maximum number of metadata items to return. Default:\
+        \ `50`                    |\n| `include_last_updated`| `Optional[bool]`  \
+        \    | Whether to include the last updated timestamp. Default: `false`   \
+        \           |\n\n## Response\n\n- **200**: Metadata retrieved successfully\
+        \  \n    - Returns: `{ \"metadata\": Deasy_Metadata, \"next_offset\": Optional[int]\
+        \ }`\n- **500**: Internal Server Error\n\n## Example\n\n```json\n{\n  \"data_connector_name\"\
+        : \"my-connector\",\n  \"dataslice_id\": \"abc123\",\n  \"tag_names\": [\"\
+        category\", \"date\"],\n  \"include_chunk_level\": true,\n  \"offset\": 0,\n\
+        \  \"limit\": 50\n}\n```"
+      operationId: list_paginated_metadata_route_metadata_list_paginated_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListPaginatedMetadataRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListPaginatedMetadataResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.list_paginated(\n    data_connector_name=\"data_connector_name\"\
+          ,\n)\nprint(response.metadata)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.listPaginated({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(response.metadata);"
+  /metadata/filtered:
+    post:
+      tags:
+      - Metadata
+      summary: Get Filtered Metadata
+      description: Get paginated filtered metadata based on conditions
+      operationId: get_filtered_metadata_metadata_filtered_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FilteredMetadataRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FilteredMetadataResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.list_filtered(\n    data_connector_name=\"data_connector_name\"\
+          ,\n)\nprint(response.metadata)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.listFiltered({\
+          \ data_connector_name: 'data_connector_name' });\n\nconsole.log(response.metadata);"
+  /metadata/get_unique_tags:
+    post:
+      tags:
+      - Metadata
+      summary: Get Unique Tags
+      description: Get a list of unique tags that have been extracted - supports shared
+        connections
+      operationId: get_unique_tags_metadata_get_unique_tags_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetUniqueTagsRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetUniqueTagsResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.list_unique_tags(\n    data_connector_name=\"\
+          data_connector_name\",\n)\nprint(response.tags)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.listUniqueTags({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(response.tags);"
+  /metadata/chunk/list:
+    post:
+      tags:
+      - Metadata
+      summary: List Chunk Metadata
+      description: Get metadata for specified files and tags
+      operationId: list_chunk_metadata_metadata_chunk_list_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListChunkMetadataRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListChunkMetadataResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.list_chunks(\n    data_connector_name=\"data_connector_name\"\
+          ,\n)\nprint(response.metadata)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.listChunks({\
+          \ data_connector_name: 'data_connector_name' });\n\nconsole.log(response.metadata);"
+  /metadata/get_evidence:
+    post:
+      tags:
+      - Metadata
+      summary: Get Evidence
+      description: Retrieve evidence for specified file and tag - supports shared
+        connections
+      operationId: get_evidence_metadata_get_evidence_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetEvidenceRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetEvidenceResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.get_evidence(\n    data_connector_name=\"data_connector_name\"\
+          ,\n    filename=\"filename\",\n    tag_id=\"tag_id\",\n    tag_value=\"\
+          string\",\n)\nprint(response.evidence)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.getEvidence({\n\
+          \  data_connector_name: 'data_connector_name',\n  filename: 'filename',\n\
+          \  tag_id: 'tag_id',\n  tag_value: 'string',\n});\n\nconsole.log(response.evidence);"
+  /metadata/delete:
+    post:
+      tags:
+      - Metadata
+      summary: Delete
+      description: "Delete metadata for specified files, tags, and/or conditions.\n\
+        \n## Request Body\n\n| Field                 | Type                | Description\
+        \                                                                  |\n|-----------------------|---------------------|------------------------------------------------------------------------------|\n\
+        | `data_connector_name` | `str`               | Name of the data connector\
+        \ (vector database profile) to delete metadata from.|\n| `file_names`    \
+        \      | `Optional[List[str]]` | List of file names to delete metadata for.\
+        \                                  |\n| `tags`                | `Optional[List[str]]`\
+        \ | List of tags to filter which metadata to delete.                     \
+        \       |\n| `conditions`          | `Optional[Condition]` | Additional conditions\
+        \ to filter which metadata to delete.                   |\n\n## Response\n\
+        \n- **200**: Metadata deleted successfully  \n    - Returns: `{ \"chunk_deleted_count\"\
+        : int, \"file_deleted_count\": int }`\n- **500**: Internal Server Error\n\n\
+        ## Example\n\n```json\n{\n  \"data_connector_name\": \"my-connector\",\n \
+        \ \"file_names\": [\"document1.pdf\", \"document2.pdf\"],\n  \"tags\": [\"\
+        archived\", \"old\"]\n}\n```"
+      operationId: delete_metadata_route_metadata_delete_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteMetadataRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteMetadataResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          metadata = client.metadata.delete(\n    data_connector_name=\"data_connector_name\"\
+          ,\n)\nprint(metadata.chunk_deleted_count)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst metadata = await client.metadata.delete({\
+          \ data_connector_name: 'data_connector_name' });\n\nconsole.log(metadata.chunk_deleted_count);"
+  /metadata/delete/values:
+    post:
+      tags:
+      - Metadata
+      summary: Delete Tag Values
+      description: Delete specific values from a tag across all files. Accepts tag_name
+        (str), values (List[str]), data_connector_name (str), and optional dataslice_id
+        (str).
+      operationId: delete_tag_values_route_metadata_delete_values_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteTagValuesRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteTagValuesResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.delete_values(\n    data_connector_name=\"data_connector_name\"\
+          ,\n    tag_name=\"tag_name\",\n    values=[\"string\"],\n)\nprint(response.chunks_modified_count)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.deleteValues({\n\
+          \  data_connector_name: 'data_connector_name',\n  tag_name: 'tag_name',\n\
+          \  values: ['string'],\n});\n\nconsole.log(response.chunks_modified_count);"
+  /metadata/standardization_db:
+    post:
+      tags:
+      - Metadata
+      summary: Standardize Metadata Db
+      description: Apply standardization mapping to metadata values in database
+      operationId: standardize_metadata_db_metadata_standardization_db_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StandardizationDBRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardizationDBResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.get_standardization_db(\n    data_connector_name=\"\
+          data_connector_name\",\n    standard_mapping={\n        \"foo\": [{}]\n\
+          \    },\n    tag_name=\"tag_name\",\n)\nprint(response.success)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.getStandardizationDB({\n\
+          \  data_connector_name: 'data_connector_name',\n  standard_mapping: { foo:\
+          \ [{}] },\n  tag_name: 'tag_name',\n});\n\nconsole.log(response.success);"
+  /metadata/standardization_suggest:
+    post:
+      tags:
+      - Metadata
+      summary: Standardize Metadata
+      description: Standardize metadata values using LLM — supports multiple tags
+        with optional auto-apply.
+      operationId: standardize_metadata_metadata_standardization_suggest_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StandardizationSuggestRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardizationSuggestResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.standardization_suggest(\n    data_connector_name=\"\
+          data_connector_name\",\n    description=\"description\",\n    tag_names=[\"\
+          string\"],\n)\nprint(response.job_id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.standardizationSuggest({\n\
+          \  data_connector_name: 'data_connector_name',\n  description: 'description',\n\
+          \  tag_names: ['string'],\n});\n\nconsole.log(response.job_id);"
+  /metadata/standardization_bulk:
+    post:
+      tags:
+      - Metadata
+      summary: Standardize Metadata Bulk
+      description: Start bulk standardization as a background task and return job
+        ID immediately.
+      operationId: standardize_metadata_bulk_metadata_standardization_bulk_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BulkStandardizationRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BulkStandardizationResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.standardization_bulk(\n    tag_names=[\"string\"\
+          ],\n    vdb_profile_name=\"vdb_profile_name\",\n)\nprint(response.job_id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.standardizationBulk({\n\
+          \  tag_names: ['string'],\n  vdb_profile_name: 'vdb_profile_name',\n});\n\
+          \nconsole.log(response.job_id);"
+  /metadata/standardize/insert:
+    post:
+      tags:
+      - Metadata
+      summary: Insert Standardization
+      description: Insert or update a standardization mapping for a tag
+      operationId: insert_standardization_metadata_standardize_insert_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StandardizationRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.metadata.standardize.insert(\n    data_connector_name=\"\
+          data_connector_name\",\n    standard_mapping={},\n    tag_id=\"tag_id\"\
+          ,\n    tag_name=\"tag_name\",\n)\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.metadata.standardize.insert({\n\
+          \  data_connector_name: 'data_connector_name',\n  standard_mapping: {},\n\
+          \  tag_id: 'tag_id',\n  tag_name: 'tag_name',\n});\n\nconsole.log(response);"
+  /metadata/standardize/list:
+    post:
+      tags:
+      - Metadata
+      summary: List Standardizations
+      description: Retrieve all standardization mappings for a user
+      operationId: list_standardizations_metadata_standardize_list_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BasicMetadataRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          standardizes = client.metadata.standardize.list(\n    data_connector_name=\"\
+          data_connector_name\",\n)\nprint(standardizes)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst standardizes = await client.metadata.standardize.list({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(standardizes);"
+  /metadata/standardize/delete:
+    post:
+      tags:
+      - Metadata
+      summary: Delete Standardization
+      description: Delete a standardization mapping
+      operationId: delete_standardization_metadata_standardize_delete_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StandardizationDeleteRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          standardize = client.metadata.standardize.delete(\n    data_connector_name=\"\
+          data_connector_name\",\n    tag_id=\"tag_id\",\n    taxonomy_name=\"taxonomy_name\"\
+          ,\n)\nprint(standardize)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst standardize = await client.metadata.standardize.delete({\n\
+          \  data_connector_name: 'data_connector_name',\n  tag_id: 'tag_id',\n  taxonomy_name:\
+          \ 'taxonomy_name',\n});\n\nconsole.log(standardize);"
+  /progress_tracker/task_status:
+    post:
+      tags:
+      - Task Tracking
+      summary: Get Status
+      description: "Get the status of a task by job ID.\n\n## Request Body\n\n| Field\
+        \    | Type  | Description                                      |\n|----------|-------|--------------------------------------------------|\n\
+        | `job_id` | `str` | The unique identifier for the job to check.      |\n\n\
+        ## Response\n\n- **200**: Task status retrieved successfully  \n    - Returns:\
+        \ `{ \"percent_complete\": float, \"tags_created\": Optional[int], \"status\"\
+        : str }`\n- **404**: Job ID not found\n\n## Example\n\n```json\n{\n  \"job_id\"\
+        : \"abc123-def456-ghi789\"\n}\n```"
+      operationId: get_task_status_route_progress_tracker_task_status_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskStatusRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskStatusResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.task_status.get_status(\n    job_id=\"job_id\",\n)\nprint(response.percent_complete)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.taskStatus.getStatus({\
+          \ job_id: 'job_id' });\n\nconsole.log(response.percent_complete);"
+  /progress_tracker/abort/{tracker_id}:
+    put:
+      tags:
+      - Task Tracking
+      summary: Abort Progress Tracker
+      description: Abort a progress tracker and update the tracker in Postgres.
+      operationId: abort_progress_tracker_progress_tracker_abort__tracker_id__put
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      parameters:
+      - name: tracker_id
+        in: path
+        required: true
+        schema:
+          type: string
+          title: Tracker Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.task_status.abort(\n    \"tracker_id\",\n)\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.taskStatus.abort('tracker_id');\n\
+          \nconsole.log(response);"
+  /progress_tracker/get_progress_trackers:
+    get:
+      tags:
+      - Task Tracking
+      summary: Get Progress Trackers
+      description: 'Get all progress trackers for a user.
+
+        When ENABLE_CONNECTION_SHARING is True, returns tasks from all users in the
+        user''s groups.'
+      operationId: get_progress_trackers_progress_tracker_get_progress_trackers_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetProgressTrackersResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          task_statuses = client.task_status.list()\nprint(task_statuses.progress_trackers)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst taskStatuses = await client.taskStatus.list();\n\
+          \nconsole.log(taskStatuses.progress_trackers);"
+  /progress_tracker/errors:
+    post:
+      tags:
+      - Task Tracking
+      summary: Get Tracker Errors
+      description: Get the errors for a progress tracker.
+      operationId: get_tracker_errors_progress_tracker_errors_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetTrackerErrorsRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetTrackerErrorsResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.task_status.get_errors(\n    tracker_id=\"tracker_id\"\
+          ,\n)\nprint(response.errors)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.taskStatus.getErrors({\
+          \ tracker_id: 'tracker_id' });\n\nconsole.log(response.errors);"
+  /progress_tracker/delete:
+    post:
+      tags:
+      - Task Tracking
+      summary: Delete Progress Trackers
+      description: 'Delete progress trackers from Postgres.
+
+        Aborts any in-progress tasks before deleting.'
+      operationId: delete_progress_trackers_progress_tracker_delete_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteProgressTrackersRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteProgressTrackersResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          task_status = client.task_status.delete(\n    tracker_ids=[\"string\"],\n\
+          )\nprint(task_status.success)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst taskStatus = await client.taskStatus.delete({\
+          \ tracker_ids: ['string'] });\n\nconsole.log(taskStatus.success);"
+  /dataslice/create:
+    post:
+      tags:
+      - Data Slices
+      summary: Create
+      description: "Create a new data slice based on specified conditions.\n\n## Request\
+        \ Body\n\n| Field             | Type           | Description             \
+        \                                                   |\n|-------------------|----------------|----------------------------------------------------------------------------|\n\
+        | `dataslice_name`  | `str`          | The name to assign to the newly created\
+        \ data slice.                        |\n| `condition`       | `Optional[List[Dict]]`\
+        \ | (Legacy) List of file qualifying conditions.                         |\n\
+        | `condition_new`   | `Optional[Any]` | New format: advanced file qualifying\
+        \ conditions.                           |\n| `description`     | `Optional[str]`\
+        \ | Description of the data slice.                                       \
+        \      |\n| `status`          | `str`          | The status of the data slice\
+        \ (e.g., active).                               |\n| `data_points`     | `Optional[int]`\
+        \ | Number of data points in the data slice.                             \
+        \      |\n| `latest_taxonomy`    | `Optional[Dict]` | Most recent taxonomy\
+        \ reference/metadata.                                      |\n| `taxonomy_id`\
+        \        | `Optional[str]` | ID of the related taxonomy, if applicable.  \
+        \                                  |\n| `data_connector_name` | `str`    \
+        \  | Name of the data connector (vector database profile).               \
+        \       |\n| `parent_dataslice_id` | `Optional[str]` | (Optional) Parent data\
+        \ slice ID, for lineage.                        |\n\n## Response\n\n- **201**:\
+        \ Data slice created successfully  \n    - Returns: `{ \"dataslice_id\": \"\
+        <uuid>\" }`\n- **500**: Internal Server Error.\n\n## Example\n\n```json\n\
+        {\n  \"dataslice_name\": \"Customer Purchases Q2\",\n  \"condition\": [\n\
+        \    { \"field\": \"created_date\", \"op\": \"gte\", \"value\": \"2024-04-01\"\
+        \ }\n  ],\n  \"description\": \"Purchase data from Q2 2024\",\n  \"status\"\
+        : \"active\",\n  \"data_points\": 4000,\n  \"data_connector_name\": \"prod-warehouse\"\
+        \n}\n```"
+      operationId: create_dataslice_route_dataslice_create_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateDatasliceRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateDatasliceResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          data_slice = client.data_slice.create(\n    data_connector_name=\"data_connector_name\"\
+          ,\n    dataslice_name=\"dataslice_name\",\n)\nprint(data_slice.dataslice_id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst dataSlice = await client.dataSlice.create({\n\
+          \  data_connector_name: 'data_connector_name',\n  dataslice_name: 'dataslice_name',\n\
+          });\n\nconsole.log(dataSlice.dataslice_id);"
+  /dataslice/list:
+    get:
+      tags:
+      - Data Slices
+      summary: List
+      description: "Retrieve all data slices associated with the currently authenticated\
+        \ user.\n\n### Response\n\nReturns a JSON object containing a list of dataslices:\n\
+        \n```json\n{\n  \"dataslices\": [\n    {\n      \"dataslice_id\": \"string\"\
+        ,\n      \"dataslice_name\": \"string\",\n      \"description\": \"string\"\
+        ,\n      \"status\": \"active\",\n      \"data_points\": 123,\n      \"latest_taxonomy\"\
+        : { /* taxonomy details */ },\n      \"taxonomy_id\": \"string\",\n      \"\
+        data_connector_name\": \"string\",\n      \"parent_dataslice_id\": \"string\
+        \ or null\"\n    },\n    ...\n  ]\n}\n```"
+      operationId: list_dataslices_route_dataslice_list_get
+      responses:
+        '200':
+          description: A list of dataslices the user can access.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListDataslicesResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          data_slices = client.data_slice.list()\nprint(data_slices.dataslices)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst dataSlices = await client.dataSlice.list();\n\
+          \nconsole.log(dataSlices.dataslices);"
+  /dataslice/delete:
+    delete:
+      tags:
+      - Data Slices
+      summary: Delete
+      description: "Delete a single data slice by its unique identifier.\n\n## Request\
+        \ Body\n\n| Field             | Type           | Description             \
+        \                                                   |\n|-------------------|----------------|----------------------------------------------------------------------------|\n\
+        | `dataslice_id`    | `str`        | The unique identifier of the data slice\
+        \ to delete.                        |\n\n### Response\n\nReturns a confirmation\
+        \ message of the successful deletion and any associated data.\n\n```json\n\
+        {\n  \"message\": \"Data slice deleted successfully\",\n  \"data\": {\n  \
+        \  // Details of deletion outcome\n  }\n}\n```"
+      operationId: delete_dataslice_route_dataslice_delete_delete
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      parameters:
+      - name: dataslice_id
+        in: query
+        required: true
+        schema:
+          type: string
+          title: Dataslice Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteDatasliceResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          data_slice = client.data_slice.delete(\n    dataslice_id=\"dataslice_id\"\
+          ,\n)\nprint(data_slice.message)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst dataSlice = await client.dataSlice.delete({\
+          \ dataslice_id: 'dataslice_id' });\n\nconsole.log(dataSlice.message);"
+  /dataslice/export/metadata:
+    post:
+      tags:
+      - Data Slices
+      summary: Export
+      description: "Export metadata for a specific data slice or the entire data connector,\
+        \ in JSON or CSV format.\n\n## Request Body\n\n| Field                   \
+        \   | Type                  | Description                                \
+        \                                        |\n|----------------------------|-----------------------|------------------------------------------------------------------------------------|\n\
+        | `data_connector_name`      | `str`                 | Name of the data connector\
+        \ to export metadata from.                                |\n| `dataslice_id`\
+        \             | `Optional[str]`       | ID of the dataslice to export metadata\
+        \ from. If omitted, all data is included.     |\n| `export_file_level`   \
+        \     | `bool`                | `True` for file-level export, `False` for\
+        \ chunk-level export.                      |\n| `export_format`          \
+        \  | `Optional[ExportFormat]` | Desired export format: `json` or `csv` (e.g.,\
+        \ `\"json\"`, `\"csv\"`).               |\n| `selected_metadata_fields` |\
+        \ `Optional[List[str]]` | List of metadata fields to include in the export.\
+        \                                  |\n\n## Response\n\n- **200**: Metadata\
+        \ exported successfully  \n    - Returns: A streaming file response containing\
+        \ the exported metadata in the requested format.\n- **500**: Internal Server\
+        \ Error\n\n## Example\n\n```json\n{\n  \"data_connector_name\": \"example-connector\"\
+        ,\n  \"dataslice_id\": \"abc123\",\n  \"export_file_level\": true,\n  \"export_format\"\
+        : \"json\",\n  \"selected_metadata_fields\": [\"field1\", \"field2\"]\n}\n\
+        ```"
+      operationId: export_data_slice_dataslice_export_metadata_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExportDatasliceMetadataRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_slice.export(\n    data_connector_name=\"data_connector_name\"\
+          ,\n)\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSlice.export({\
+          \ data_connector_name: 'data_connector_name' });\n\nconsole.log(response);"
+  /dataslice/export/vdb:
+    post:
+      tags:
+      - Data Slices
+      summary: Export Dataslice2Vdb
+      description: Export metadata for a data slice to a target vector database
+      operationId: export_dataslice2vdb_dataslice_export_vdb_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExportDatasliceVDBRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExportDatasliceVDBResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_slice.export_vdb(\n    target_data_connector_name=\"\
+          target_data_connector_name\",\n)\nprint(response.details)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSlice.exportVdb({\n\
+          \  target_data_connector_name: 'target_data_connector_name',\n});\n\nconsole.log(response.details);"
+  /dataslice/file_count:
+    post:
+      tags:
+      - Data Slices
+      summary: Get Dataslice File Count
+      description: 'Get count of files matching dataslice conditions or provided conditions
+
+        Supports shared connections for Contributors and Admins.'
+      operationId: get_dataslice_file_count_dataslice_file_count_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DatasliceFileCountRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasliceFileCountResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_slice.file_count(\n    data_connector_name=\"data_connector_name\"\
+          ,\n)\nprint(response.file_count)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSlice.fileCount({\
+          \ data_connector_name: 'data_connector_name' });\n\nconsole.log(response.file_count);"
+  /dataslice/sync_score:
+    post:
+      tags:
+      - Data Slices
+      summary: Check Dataslice Sync Endpoint
+      description: Check the synchronization status of a specific data slice
+      operationId: check_dataslice_sync_endpoint_dataslice_sync_score_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SyncScoreRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SyncScoreResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_slice.sync_score()\nprint(response.deasy_sync_percentage)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSlice.syncScore();\n\
+          \nconsole.log(response.deasy_sync_percentage);"
+  /dataslice/suggest:
+    post:
+      tags:
+      - Data Slices
+      summary: Suggest Endpoint
+      description: Suggest a data slice
+      operationId: suggest_endpoint_dataslice_suggest_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DatasliceSuggestRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasliceSuggestResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_slice.suggest(\n    data_connector_name=\"data_connector_name\"\
+          ,\n)\nprint(response.suggested_dataslices)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSlice.suggest({\
+          \ data_connector_name: 'data_connector_name' });\n\nconsole.log(response.suggested_dataslices);"
+  /dataslice/metrics:
+    post:
+      tags:
+      - Data Slices
+      summary: Get Dataslice Metrics Endpoint
+      description: Retrieve data slice metrics
+      operationId: get_dataslice_metrics_endpoint_dataslice_metrics_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DatasliceMetricsRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DatasliceMetricsResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.data_slice.metrics()\nprint(response.metadata_tag_counts_distribution)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.dataSlice.metrics();\n\
+          \nconsole.log(response.metadata_tag_counts_distribution);"
+  /workflows/upsert:
+    post:
+      tags:
+      - Workflows
+      summary: Upsert Workflow
+      description: Upsert a workflow
+      operationId: upsert_workflow_workflows_upsert_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertWorkflowRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.workflows.upsert(\n    workflow={\n        \"cadence\"\
+          : \"cadence\",\n        \"name\": \"name\",\n        \"stages\": [{\n  \
+          \          \"jobs\": [{\n                \"endpoint\": \"endpoint\",\n \
+          \               \"endpoint_request_body\": {},\n            }]\n       \
+          \ }],\n    },\n)\nprint(response.workflow_id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.workflows.upsert({\n\
+          \  workflow: {\n    cadence: 'cadence',\n    name: 'name',\n    stages:\
+          \ [\n      {\n        jobs: [\n          {\n            endpoint: 'endpoint',\n\
+          \            endpoint_request_body: {},\n          },\n        ],\n    \
+          \  },\n    ],\n  },\n});\n\nconsole.log(response.workflow_id);"
+  /workflows/list:
+    post:
+      tags:
+      - Workflows
+      summary: List Workflows
+      description: List workflows
+      operationId: list_workflows_workflows_list_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListWorkflowRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListWorkflowResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          workflows = client.workflows.list()\nprint(workflows.workflows)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst workflows = await client.workflows.list();\n\
+          \nconsole.log(workflows.workflows);"
+  /workflows/delete:
+    post:
+      tags:
+      - Workflows
+      summary: Delete Workflow
+      description: Delete a workflow
+      operationId: delete_workflow_workflows_delete_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeleteWorkflowRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          workflow = client.workflows.delete(\n    workflow_id=\"workflow_id\",\n\
+          )\nprint(workflow.workflow_id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst workflow = await client.workflows.delete({\
+          \ workflow_id: 'workflow_id' });\n\nconsole.log(workflow.workflow_id);"
+  /workflows/execute:
+    post:
+      tags:
+      - Workflows
+      summary: Execute Workflow
+      description: Execute a workflow
+      operationId: execute_workflow_workflows_execute_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ExecuteWorkflowRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WorkflowResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.workflows.execute(\n    workflow_id=\"workflow_id\",\n\
+          )\nprint(response.workflow_id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.workflows.execute({\
+          \ workflow_id: 'workflow_id' });\n\nconsole.log(response.workflow_id);"
+  /projects/create:
+    post:
+      tags:
+      - Projects
+      summary: Create Project
+      operationId: create_project_projects_create_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateProjectRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          project = client.projects.create(\n    name=\"name\",\n)\nprint(project.id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst project = await client.projects.create({\
+          \ name: 'name' });\n\nconsole.log(project.id);"
+  /projects/list:
+    post:
+      tags:
+      - Projects
+      summary: List Projects
+      operationId: list_projects_projects_list_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ListProjectsRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListProjectsResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          projects = client.projects.list()\nprint(projects.limit)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst projects = await client.projects.list();\n\
+          \nconsole.log(projects.limit);"
+  /projects/{project_id}:
+    get:
+      tags:
+      - Projects
+      summary: Get Project
+      operationId: get_project_projects__project_id__get
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      parameters:
+      - name: project_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Project Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          project = client.projects.get(\n    \"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e\"\
+          ,\n)\nprint(project.id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst project = await client.projects.get('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e');\n\
+          \nconsole.log(project.id);"
+    put:
+      tags:
+      - Projects
+      summary: Update Project
+      operationId: update_project_projects__project_id__put
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      parameters:
+      - name: project_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Project Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateProjectRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          project = client.projects.update(\n    project_id=\"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e\"\
+          ,\n    name=\"name\",\n)\nprint(project.id)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst project = await client.projects.update('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e',\
+          \ {\n  name: 'name',\n});\n\nconsole.log(project.id);"
+    delete:
+      tags:
+      - Projects
+      summary: Delete Project
+      operationId: delete_project_projects__project_id__delete
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      parameters:
+      - name: project_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Project Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteProjectResponse'
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          project = client.projects.delete(\n    \"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e\"\
+          ,\n)\nprint(project.message)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst project = await client.projects.delete('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e');\n\
+          \nconsole.log(project.message);"
+  /projects/{project_id}/sensitive-data:
+    get:
+      tags:
+      - Projects
+      summary: Get Project Sensitive Data
+      operationId: get_project_sensitive_data_projects__project_id__sensitive_data_get
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      parameters:
+      - name: project_id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+          title: Project Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.projects.get_sensitive_data(\n    \"182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e\"\
+          ,\n)\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.projects.getSensitiveData('182bd5e5-6e1a-4fe4-a799-aa6d9a6ab26e');\n\
+          \nconsole.log(response);"
+  /versioning/run:
+    post:
+      tags:
+      - Versioning
+      summary: Run Versioning
+      description: Test the GPU
+      operationId: run_versioning_versioning_run_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VersioningRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.versioning.run(\n    data_connector_name=\"data_connector_name\"\
+          ,\n    job_id=\"job_id\",\n)\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.versioning.run({\n\
+          \  data_connector_name: 'data_connector_name',\n  job_id: 'job_id',\n});\n\
+          \nconsole.log(response);"
+  /versioning/retrieve_versions:
+    post:
+      tags:
+      - Versioning
+      summary: Retrieve Versions
+      description: Test the GPU get versions
+      operationId: retrieve_versions_versioning_retrieve_versions_post
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetrieveVersionsRequest'
+        required: true
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema: {}
+        '403':
+          description: Missing token
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '404':
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+        '429':
+          description: Too many requests
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+        '500':
+          description: Internal Server Error. An unexpected error occurred while processing
+            the request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPError'
+      security:
+      - BasicAuth: []
+      - BearerAuth: []
+        UserIdAuth: []
+      x-codeSamples:
+      - lang: Python
+        source: "import os\nfrom unstructured import UnstructuredClient\n\nclient\
+          \ = UnstructuredClient(\n    username=os.environ.get(\"UNSTRUCTURED_USERNAME\"\
+          ),  # This is the default and can be omitted\n    password=os.environ.get(\"\
+          UNSTRUCTURED_PASSWORD\"),  # This is the default and can be omitted\n)\n\
+          response = client.versioning.retrieve_versions(\n    data_connector_name=\"\
+          data_connector_name\",\n)\nprint(response)"
+      - lang: JavaScript
+        source: "import UnstructuredClient from 'unstructured-sdk';\n\nconst client\
+          \ = new UnstructuredClient({\n  authMethod: 'My Auth Method',\n  username:\
+          \ process.env['UNSTRUCTURED_USERNAME'], // This is the default and can be\
+          \ omitted\n  password: process.env['UNSTRUCTURED_PASSWORD'], // This is\
+          \ the default and can be omitted\n});\n\nconst response = await client.versioning.retrieveVersions({\n\
+          \  data_connector_name: 'data_connector_name',\n});\n\nconsole.log(response);"
 components:
   schemas:
     AzureSQLDestinationConfig:
       properties:
         type:
           type: string
+          enum:
+          - AzureSQLNodeDestinationManager
           const: AzureSQLNodeDestinationManager
           title: Type
           default: AzureSQLNodeDestinationManager
@@ -2389,6 +6569,181 @@ components:
       required:
       - name
       title: BaseTag
+    BasicMetadataRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+      type: object
+      required:
+      - data_connector_name
+      title: BasicMetadataRequest
+    BatchConnectorResponse:
+      properties:
+        profile_ids:
+          items:
+            type: string
+          type: array
+          title: Profile Ids
+      type: object
+      required:
+      - profile_ids
+      title: BatchConnectorResponse
+    BatchCreateVDBConnectorRequest:
+      properties:
+        connectors:
+          items:
+            $ref: '#/components/schemas/CreateVDBConnectorRequest'
+          type: array
+          title: Connectors
+      type: object
+      required:
+      - connectors
+      title: BatchCreateVDBConnectorRequest
+    BatchDeleteConnectorRequest:
+      properties:
+        connector_names:
+          items:
+            type: string
+          type: array
+          title: Connector Names
+      type: object
+      required:
+      - connector_names
+      title: BatchDeleteConnectorRequest
+    BatchDeleteConnectorResponse:
+      properties:
+        deleted:
+          items:
+            type: string
+          type: array
+          title: Deleted
+        not_found:
+          items:
+            type: string
+          type: array
+          title: Not Found
+      type: object
+      required:
+      - deleted
+      - not_found
+      title: BatchDeleteConnectorResponse
+    BulkStandardizationRequest:
+      properties:
+        vdb_profile_name:
+          type: string
+          title: Vdb Profile Name
+        tag_names:
+          items:
+            type: string
+          type: array
+          title: Tag Names
+          description: List of tag names to standardize.
+        only_dedupe:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Only Dedupe
+          description: If True, only perform simple keyword-based deduplication.
+          default: true
+        job_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Job Id
+        taxonomy_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Taxonomy Name
+      type: object
+      required:
+      - vdb_profile_name
+      - tag_names
+      title: BulkStandardizationRequest
+    BulkStandardizationResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+        standardization_results:
+          items:
+            $ref: '#/components/schemas/StandardizationResult'
+          type: array
+          title: Standardization Results
+          description: Results for tags successfully processed.
+        failed_tags:
+          additionalProperties:
+            type: string
+          type: object
+          title: Failed Tags
+          description: Tags that failed standardization, with error messages.
+        job_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Job Id
+          description: Job ID for tracking background task status.
+        status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Status
+          description: Current status of the standardization job.
+        message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Message
+          description: Status message for the job.
+        updated_searchability_scores:
+          anyOf:
+          - additionalProperties:
+              type: number
+            type: object
+          - type: 'null'
+          title: Updated Searchability Scores
+          description: Updated searchability scores after standardization.
+      type: object
+      required:
+      - success
+      title: BulkStandardizationResponse
+    BulkUpsertTagRequest:
+      properties:
+        tag_data:
+          items:
+            $ref: '#/components/schemas/Tag-Input'
+          type: array
+          title: Tag Data
+      type: object
+      required:
+      - tag_data
+      title: BulkUpsertTagRequest
+    BulkUpsertTagResponse:
+      properties:
+        tag_names:
+          items:
+            type: string
+          type: array
+          title: Tag Names
+        available_values_added_by_tag:
+          additionalProperties:
+            items:
+              type: string
+            type: array
+          type: object
+          title: Available Values Added By Tag
+        failed_tags:
+          items:
+            type: string
+          type: array
+          title: Failed Tags
+      type: object
+      required:
+      - tag_names
+      - available_values_added_by_tag
+      - failed_tags
+      title: BulkUpsertTagResponse
     ClassifyBulkRequest:
       properties:
         data_connector_name:
@@ -2429,8 +6784,7 @@ components:
           title: Hierarchy Name
         hierarchy_data:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Hierarchy Data
           default: {}
@@ -2502,8 +6856,7 @@ components:
           title: Hierarchy Name
         hierarchy_data:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Hierarchy Data
           default: {}
@@ -2523,8 +6876,7 @@ components:
           title: Message
         output:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Output
       type: object
@@ -2603,8 +6955,7 @@ components:
           title: Data Points
         latest_taxonomy:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Latest Taxonomy
         taxonomy_id:
@@ -2640,34 +6991,114 @@ components:
           type: string
           title: Connector Name
         connector_body:
-          anyOf:
+          oneOf:
           - $ref: '#/components/schemas/SharepointDestinationConfig'
+          - $ref: '#/components/schemas/OnedriveDestinationConfig'
           - $ref: '#/components/schemas/PostgresDestinationConfig'
           - $ref: '#/components/schemas/AzureSQLDestinationConfig'
+          - $ref: '#/components/schemas/S3DestinationConfig'
           title: Connector Body
+          discriminator:
+            propertyName: type
+            mapping:
+              AzureSQLNodeDestinationManager: '#/components/schemas/AzureSQLDestinationConfig'
+              OnedriveNodeDestinationManager: '#/components/schemas/OnedriveDestinationConfig'
+              PostgresNodeDestinationManager: '#/components/schemas/PostgresDestinationConfig'
+              S3NodeDestinationManager: '#/components/schemas/S3DestinationConfig'
+              SharepointNodeDestinationManager: '#/components/schemas/SharepointDestinationConfig'
       type: object
       required:
       - connector_name
       - connector_body
       title: CreateDestinationConnectorRequest
+    CreateProjectRequest:
+      properties:
+        name:
+          type: string
+          title: Name
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        data_source:
+          items:
+            type: string
+          type: array
+          title: Data Source
+        data_slice:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Data Slice
+        taxonomy:
+          items:
+            type: string
+          type: array
+          title: Taxonomy
+        sensitive_data:
+          type: boolean
+          title: Sensitive Data
+          default: false
+        unique_data:
+          type: boolean
+          title: Unique Data
+          default: false
+        relevant_data:
+          type: boolean
+          title: Relevant Data
+          default: false
+      type: object
+      required:
+      - name
+      title: CreateProjectRequest
+    CreateTagRequest:
+      properties:
+        tag_data:
+          $ref: '#/components/schemas/Tag-Input'
+      type: object
+      required:
+      - tag_data
+      title: CreateTagRequest
+    CreateTagResponse:
+      properties:
+        tag_name:
+          type: string
+          title: Tag Name
+        tag:
+          $ref: '#/components/schemas/Tag-Output'
+      type: object
+      required:
+      - tag_name
+      - tag
+      title: CreateTagResponse
     CreateVDBConnectorRequest:
       properties:
         connector_name:
           type: string
           title: Connector Name
         connector_body:
-          anyOf:
+          oneOf:
+          - $ref: '#/components/schemas/OnedriveConnectorConfig'
           - $ref: '#/components/schemas/PSQLConnectorConfig'
           - $ref: '#/components/schemas/QdrantConnectorConfig'
           - $ref: '#/components/schemas/S3ConnectorConfig'
           - $ref: '#/components/schemas/SharepointConnectorConfig'
           title: Connector Body
+          discriminator:
+            propertyName: type
+            mapping:
+              OnedriveDataSourceManager: '#/components/schemas/OnedriveConnectorConfig'
+              PSQLVectorDBManager: '#/components/schemas/PSQLConnectorConfig'
+              QdrantVectorDBManager: '#/components/schemas/QdrantConnectorConfig'
+              S3DataSourceManager: '#/components/schemas/S3ConnectorConfig'
+              SharepointDataSourceManager: '#/components/schemas/SharepointConnectorConfig'
       type: object
       required:
       - connector_name
       - connector_body
       title: CreateVDBConnectorRequest
-    DataSliceModel:
+    DataSliceModel-Output:
       properties:
         id:
           type: string
@@ -2704,8 +7135,7 @@ components:
           - type: 'null'
         stats:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Stats
         vdb_profile_id:
@@ -2723,7 +7153,125 @@ components:
       - id
       - datasource
       title: DataSliceModel
-    DeasyTaxonomy:
+    DatasliceFileCountRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        condition:
+          anyOf:
+          - $ref: '#/components/schemas/Condition-Input'
+          - type: 'null'
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+      type: object
+      required:
+      - data_connector_name
+      title: DatasliceFileCountRequest
+    DatasliceFileCountResponse:
+      properties:
+        file_count:
+          type: integer
+          title: File Count
+      type: object
+      required:
+      - file_count
+      title: DatasliceFileCountResponse
+    DatasliceMetricsRequest:
+      properties:
+        file_names:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: File Names
+        node_ids:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Node Ids
+        tags:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Tags
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+        data_connector_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Data Connector Name
+      type: object
+      title: DatasliceMetricsRequest
+    DatasliceMetricsResponse:
+      properties:
+        unique_metadata_tags:
+          type: integer
+          title: Unique Metadata Tags
+        total_metadata_tags:
+          type: integer
+          title: Total Metadata Tags
+        total_node_count:
+          type: integer
+          title: Total Node Count
+        total_file_count:
+          type: integer
+          title: Total File Count
+        metadata_tag_counts_distribution:
+          additionalProperties:
+            items:
+              anyOf:
+              - type: integer
+              - type: number
+            type: array
+          type: object
+          title: Metadata Tag Counts Distribution
+      type: object
+      required:
+      - unique_metadata_tags
+      - total_metadata_tags
+      - total_node_count
+      - total_file_count
+      - metadata_tag_counts_distribution
+      title: DatasliceMetricsResponse
+    DatasliceSuggestRequest:
+      properties:
+        user_context:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Context
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+      type: object
+      required:
+      - data_connector_name
+      title: DatasliceSuggestRequest
+    DatasliceSuggestResponse:
+      properties:
+        suggested_dataslices:
+          items:
+            $ref: '#/components/schemas/DataSliceModel-Output'
+          type: array
+          title: Suggested Dataslices
+      type: object
+      required:
+      - suggested_dataslices
+      title: DatasliceSuggestResponse
+    DeasyTaxonomy-Output:
       properties:
         taxonomy_id:
           type: string
@@ -2735,9 +7283,7 @@ components:
           type: string
           title: Taxonomy Description
         taxonomy_data:
-          additionalProperties: true
-          type: object
-          title: Taxonomy Data
+          $ref: '#/components/schemas/TaxonomyGraph-Output'
         user_id:
           type: string
           title: User Id
@@ -2782,13 +7328,12 @@ components:
           type: string
           title: Message
         data:
-          additionalProperties: true
           type: object
           title: Data
+          default: {}
       type: object
       required:
       - message
-      - data
       title: DeleteDatasliceResponse
     DeleteDestinationConnectorRequest:
       properties:
@@ -2839,6 +7384,232 @@ components:
       - chunk_deleted_count
       - file_deleted_count
       title: DeleteMetadataResponse
+    DeleteProgressTrackersRequest:
+      properties:
+        tracker_ids:
+          items:
+            type: string
+          type: array
+          title: Tracker Ids
+      type: object
+      required:
+      - tracker_ids
+      title: DeleteProgressTrackersRequest
+    DeleteProgressTrackersResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+      type: object
+      required:
+      - success
+      title: DeleteProgressTrackersResponse
+    DeleteProjectResponse:
+      properties:
+        message:
+          type: string
+          title: Message
+      type: object
+      required:
+      - message
+      title: DeleteProjectResponse
+    DeleteTagValuesRequest:
+      properties:
+        tag_name:
+          type: string
+          title: Tag Name
+        values:
+          items:
+            type: string
+          type: array
+          title: Values
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+      type: object
+      required:
+      - tag_name
+      - values
+      - data_connector_name
+      title: DeleteTagValuesRequest
+    DeleteTagValuesResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+        files_modified_count:
+          type: integer
+          title: Files Modified Count
+        chunks_modified_count:
+          type: integer
+          title: Chunks Modified Count
+      type: object
+      required:
+      - success
+      - files_modified_count
+      - chunks_modified_count
+      title: DeleteTagValuesResponse
+    DeleteWorkflowRequest:
+      properties:
+        workflow_id:
+          type: string
+          title: Workflow Id
+      type: object
+      required:
+      - workflow_id
+      title: DeleteWorkflowRequest
+    DocumentTextRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        file_names:
+          items:
+            type: string
+          type: array
+          title: File Names
+        chunk_ids:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Chunk Ids
+      type: object
+      required:
+      - data_connector_name
+      - file_names
+      title: DocumentTextRequest
+    DocumentTextResponse:
+      properties:
+        file_to_nodes_to_text:
+          additionalProperties:
+            additionalProperties:
+              type: string
+            type: object
+          type: object
+          title: File To Nodes To Text
+      type: object
+      required:
+      - file_to_nodes_to_text
+      title: DocumentTextResponse
+    EdgeCondition:
+      properties:
+        node_id:
+          type: string
+          title: Node Id
+          description: ID of the node whose value must match
+        tag_value_name:
+          type: string
+          title: Tag Value Name
+          description: The tag value that must match
+      type: object
+      required:
+      - node_id
+      - tag_value_name
+      title: EdgeCondition
+      description: A single condition that must be met for an edge to be followed.
+    EvaluateTestCasesRequest:
+      properties:
+        patterns:
+          items:
+            $ref: '#/components/schemas/RegexPatternEvaluate'
+          type: array
+          title: Patterns
+        test_cases:
+          items:
+            $ref: '#/components/schemas/TestCase'
+          type: array
+          title: Test Cases
+      type: object
+      required:
+      - patterns
+      - test_cases
+      title: EvaluateTestCasesRequest
+      description: Request to evaluate test cases against multiple regex patterns.
+    EvaluateTestCasesResponse:
+      properties:
+        evaluated_test_cases:
+          items:
+            $ref: '#/components/schemas/EvaluatedTestCase'
+          type: array
+          title: Evaluated Test Cases
+      type: object
+      required:
+      - evaluated_test_cases
+      title: EvaluateTestCasesResponse
+      description: Response from evaluating test cases.
+    EvaluatedTestCase:
+      properties:
+        text:
+          type: string
+          title: Text
+        should_match:
+          type: boolean
+          title: Should Match
+        actual_match:
+          type: boolean
+          title: Actual Match
+        category:
+          type: string
+          title: Category
+        matched_patterns:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Matched Patterns
+      type: object
+      required:
+      - text
+      - should_match
+      - actual_match
+      - category
+      title: EvaluatedTestCase
+      description: Result of evaluating a test case against patterns.
+    EvidenceExample:
+      properties:
+        value:
+          type: string
+          title: Value
+        evidence:
+          type: string
+          title: Evidence
+        is_positive:
+          type: boolean
+          title: Is Positive
+          default: true
+        source:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source
+        document_size:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Document Size
+      type: object
+      required:
+      - value
+      - evidence
+      title: EvidenceExample
+      description: Evidence from user highlights for empirical context extraction.
+    ExecuteWorkflowRequest:
+      properties:
+        workflow_id:
+          type: string
+          title: Workflow Id
+      type: object
+      required:
+      - workflow_id
+      title: ExecuteWorkflowRequest
     ExportDatasliceDestinationRequest:
       properties:
         dataslice_id:
@@ -2942,6 +7713,46 @@ components:
       required:
       - data_connector_name
       title: ExportDatasliceMetadataRequest
+    ExportDatasliceVDBRequest:
+      properties:
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+        ori_data_connector_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Ori Data Connector Name
+        target_data_connector_name:
+          type: string
+          title: Target Data Connector Name
+        export_tags:
+          items: {}
+          type: array
+          title: Export Tags
+          default: []
+        export_level:
+          $ref: '#/components/schemas/ExportLevel'
+          default: both
+      type: object
+      required:
+      - target_data_connector_name
+      title: ExportDatasliceVDBRequest
+    ExportDatasliceVDBResponse:
+      properties:
+        message:
+          type: string
+          title: Message
+        details:
+          type: object
+          title: Details
+      type: object
+      required:
+      - message
+      - details
+      title: ExportDatasliceVDBResponse
     ExportFormat:
       type: string
       enum:
@@ -2955,6 +7766,427 @@ components:
       - chunk
       - both
       title: ExportLevel
+    FilteredMetadataRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        conditions:
+          anyOf:
+          - $ref: '#/components/schemas/Condition-Input'
+          - type: 'null'
+        node_condition:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/TagCondition'
+            type: array
+          - type: 'null'
+          title: Node Condition
+          default: []
+        offset:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Offset
+          default: 0
+        limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Limit
+          default: 50
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+        search_query:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Search Query
+      type: object
+      required:
+      - data_connector_name
+      title: FilteredMetadataRequest
+    FilteredMetadataResponse:
+      properties:
+        metadata:
+          additionalProperties:
+            type: object
+          type: object
+          title: Metadata
+        total_matches:
+          type: integer
+          title: Total Matches
+        next_offset:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Next Offset
+      type: object
+      required:
+      - metadata
+      - total_matches
+      - next_offset
+      title: FilteredMetadataResponse
+    GenerateTaxonomyFromContextRequest:
+      properties:
+        user_context:
+          type: string
+          title: User Context
+        taxonomy_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Taxonomy Name
+        industry:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Industry
+        data_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Data Type
+        use_case:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Use Case
+        taxonomy_type:
+          type: string
+          title: Taxonomy Type
+          default: hierarchical
+        max_depth:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Max Depth
+          default: 3
+        llm_profile_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Llm Profile Name
+        data_connector_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Data Connector Name
+        validate_tags:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Validate Tags
+          default: false
+      type: object
+      required:
+      - user_context
+      title: GenerateTaxonomyFromContextRequest
+    GenerateTaxonomyFromContextResponse:
+      properties:
+        taxonomy_data:
+          type: object
+          title: Taxonomy Data
+        taxonomy_description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Taxonomy Description
+        suggested_tags:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Suggested Tags
+        tag_not_found_rates:
+          anyOf:
+          - additionalProperties:
+              type: number
+            type: object
+          - type: 'null'
+          title: Tag Not Found Rates
+      type: object
+      required:
+      - taxonomy_data
+      title: GenerateTaxonomyFromContextResponse
+    GenerateTestCasesRequest:
+      properties:
+        pattern_descriptions:
+          items:
+            type: string
+          type: array
+          title: Pattern Descriptions
+        existing_patterns:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Existing Patterns
+          default: []
+        tag_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tag Name
+        tag_description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Tag Description
+        available_values:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Available Values
+          default: []
+        existing_positive_examples:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Existing Positive Examples
+          default: []
+        existing_negative_examples:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Existing Negative Examples
+          default: []
+        output_values:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Output Values
+          default: []
+        context_keywords:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Context Keywords
+          default: []
+      type: object
+      required:
+      - pattern_descriptions
+      title: GenerateTestCasesRequest
+    GenerateTestCasesResponse:
+      properties:
+        test_cases:
+          items:
+            $ref: '#/components/schemas/TestCase'
+          type: array
+          title: Test Cases
+      type: object
+      required:
+      - test_cases
+      title: GenerateTestCasesResponse
+    GetEvidenceRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        filename:
+          type: string
+          title: Filename
+        tag_id:
+          type: string
+          title: Tag Id
+        tag_value:
+          anyOf:
+          - type: string
+          - type: number
+          - type: integer
+          title: Tag Value
+      type: object
+      required:
+      - data_connector_name
+      - filename
+      - tag_id
+      - tag_value
+      title: GetEvidenceRequest
+    GetEvidenceResponse:
+      properties:
+        evidence:
+          type: object
+          title: Evidence
+      type: object
+      required:
+      - evidence
+      title: GetEvidenceResponse
+    GetOCRPageTextRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        file_name:
+          type: string
+          title: File Name
+        page_number:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Page Number
+        chunk_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Chunk Id
+      type: object
+      required:
+      - data_connector_name
+      - file_name
+      title: GetOCRPageTextRequest
+    GetOCRPageTextResponse:
+      properties:
+        total_page_count:
+          type: integer
+          title: Total Page Count
+        page_text:
+          type: string
+          title: Page Text
+        page_number:
+          type: integer
+          title: Page Number
+      type: object
+      required:
+      - total_page_count
+      - page_text
+      - page_number
+      title: GetOCRPageTextResponse
+    GetProgressTrackersResponse:
+      properties:
+        progress_trackers:
+          type: object
+          title: Progress Trackers
+      type: object
+      required:
+      - progress_trackers
+      title: GetProgressTrackersResponse
+    GetTrackerErrorsRequest:
+      properties:
+        tracker_id:
+          type: string
+          title: Tracker Id
+        limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Limit
+        offset:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Offset
+        include_error_messages:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Include Error Messages
+          default: true
+      type: object
+      required:
+      - tracker_id
+      title: GetTrackerErrorsRequest
+    GetTrackerErrorsResponse:
+      properties:
+        errors:
+          additionalProperties:
+            anyOf:
+            - type: string
+            - type: 'null'
+          type: object
+          title: Errors
+      type: object
+      required:
+      - errors
+      title: GetTrackerErrorsResponse
+    GetUniqueTagsRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        file_names:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: File Names
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+        node_condition:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/TagCondition'
+            type: array
+          - type: 'null'
+          title: Node Condition
+      type: object
+      required:
+      - data_connector_name
+      title: GetUniqueTagsRequest
+    GetUniqueTagsResponse:
+      properties:
+        tags:
+          items:
+            type: string
+          type: array
+          title: Tags
+      type: object
+      required:
+      - tags
+      title: GetUniqueTagsResponse
+    GovernanceMetadata:
+      properties:
+        record_code:
+          type: string
+          title: Record Code
+          description: Unique identifier from the retention schedule (e.g., FIN-001)
+        retention_period:
+          type: string
+          title: Retention Period
+          description: How long to retain (e.g., '7 years', 'Permanent')
+        retention_trigger:
+          type: string
+          title: Retention Trigger
+          description: Event that starts the retention clock (e.g., 'Date of payment')
+        disposition:
+          type: string
+          title: Disposition
+          description: Action after retention expires (e.g., 'Destroy', 'Archive')
+        ingestion_id:
+          type: string
+          title: Ingestion Id
+          description: UUID grouping all tags from the same CSV upload
+      type: object
+      required:
+      - record_code
+      - retention_period
+      - retention_trigger
+      - disposition
+      - ingestion_id
+      title: GovernanceMetadata
+      description: 'Structured metadata for retention/policy governance tags.
+
+
+        Populated when a tag is ingested from a retention schedule (CSV or Collibra
+        Standards).
+
+        Stored as JSONB in the tagschemas table.'
     GraphNode:
       properties:
         label:
@@ -2973,6 +8205,7 @@ components:
           default: []
       type: object
       title: GraphNode
+      description: Legacy graph node model - kept for backwards compatibility
     GraphTagType:
       type: string
       enum:
@@ -3008,11 +8241,50 @@ components:
       - aborted
       - failed
       title: JobStatus
+    ListChunkMetadataRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        metadata_keys:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Metadata Keys
+        file_names:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: File Names
+        search_query:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Search Query
+      type: object
+      required:
+      - data_connector_name
+      title: ListChunkMetadataRequest
+    ListChunkMetadataResponse:
+      properties:
+        metadata:
+          additionalProperties:
+            type: object
+          type: object
+          title: Metadata
+      type: object
+      required:
+      - metadata
+      title: ListChunkMetadataResponse
     ListDataslicesResponse:
       properties:
         dataslices:
           items:
-            $ref: '#/components/schemas/DataSliceModel'
+            $ref: '#/components/schemas/DataSliceModel-Output'
           type: array
           title: Dataslices
       type: object
@@ -3023,10 +8295,20 @@ components:
       properties:
         connectors:
           additionalProperties:
-            anyOf:
+            oneOf:
             - $ref: '#/components/schemas/SharepointDestinationConfig'
+            - $ref: '#/components/schemas/OnedriveDestinationConfig'
             - $ref: '#/components/schemas/PostgresDestinationConfig'
             - $ref: '#/components/schemas/AzureSQLDestinationConfig'
+            - $ref: '#/components/schemas/S3DestinationConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                AzureSQLNodeDestinationManager: '#/components/schemas/AzureSQLDestinationConfig'
+                OnedriveNodeDestinationManager: '#/components/schemas/OnedriveDestinationConfig'
+                PostgresNodeDestinationManager: '#/components/schemas/PostgresDestinationConfig'
+                S3NodeDestinationManager: '#/components/schemas/S3DestinationConfig'
+                SharepointNodeDestinationManager: '#/components/schemas/SharepointDestinationConfig'
           type: object
           title: Connectors
       type: object
@@ -3070,6 +8352,12 @@ components:
             type: array
           - type: 'null'
           title: Chunk Ids
+        include_last_updated:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Include Last Updated
+          default: false
       type: object
       required:
       - data_connector_name
@@ -3083,16 +8371,48 @@ components:
                 $ref: '#/components/schemas/TagMetadata'
               type: object
             type: object
+            title: MetadataByTagAndChunk
           - additionalProperties:
               additionalProperties:
                 $ref: '#/components/schemas/Metadata'
               type: object
             type: object
+            title: MetadataByChunk
           title: Metadata
       type: object
       required:
       - metadata
       title: ListMetadataResponse
+    ListOnedriveSitesRequest:
+      properties:
+        client_id:
+          type: string
+          title: Client Id
+        client_secret:
+          type: string
+          title: Client Secret
+        tenant_id:
+          type: string
+          title: Tenant Id
+      type: object
+      required:
+      - client_id
+      - client_secret
+      - tenant_id
+      title: ListOnedriveSitesRequest
+      description: Request model for listing OneDrive sites.
+    ListOnedriveSitesResponse:
+      properties:
+        sites:
+          items:
+            $ref: '#/components/schemas/OnedriveSiteInfo'
+          type: array
+          title: Sites
+      type: object
+      required:
+      - sites
+      title: ListOnedriveSitesResponse
+      description: Response model for listing OneDrive sites.
     ListPaginatedMetadataRequest:
       properties:
         data_connector_name:
@@ -3128,6 +8448,12 @@ components:
           - type: 'null'
           title: Limit
           default: 50
+        include_last_updated:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Include Last Updated
+          default: false
       type: object
       required:
       - data_connector_name
@@ -3141,11 +8467,13 @@ components:
                 $ref: '#/components/schemas/TagMetadata'
               type: object
             type: object
+            title: MetadataByTagAndChunk
           - additionalProperties:
               additionalProperties:
                 $ref: '#/components/schemas/Metadata'
               type: object
             type: object
+            title: MetadataByChunk
           title: Metadata
         next_offset:
           anyOf:
@@ -3157,6 +8485,210 @@ components:
       - metadata
       - next_offset
       title: ListPaginatedMetadataResponse
+    ListPaginatedRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        limit:
+          type: integer
+          title: Limit
+          default: 50
+        offset:
+          anyOf:
+          - type: integer
+          - type: string
+          title: Offset
+          default: 0
+        group_by:
+          type: string
+          title: Group By
+          default: file
+        scroll_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Scroll Limit
+        hard_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Hard Limit
+        entities_already_scrolled:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Entities Already Scrolled
+          default: []
+        search_query:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Search Query
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+      type: object
+      required:
+      - data_connector_name
+      title: ListPaginatedRequest
+    ListPaginatedResponse:
+      properties:
+        entities:
+          items:
+            type: string
+          type: array
+          title: Entities
+        next_offset:
+          anyOf:
+          - {}
+          - type: 'null'
+          title: Next Offset
+        error_message:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Error Message
+      type: object
+      required:
+      - entities
+      title: ListPaginatedResponse
+    ListProjectsRequest:
+      properties:
+        limit:
+          type: integer
+          title: Limit
+          default: 100
+        offset:
+          type: integer
+          title: Offset
+          default: 0
+        search_query:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Search Query
+      type: object
+      title: ListProjectsRequest
+    ListProjectsResponse:
+      properties:
+        projects:
+          items:
+            $ref: '#/components/schemas/ProjectResponse'
+          type: array
+          title: Projects
+        total:
+          type: integer
+          title: Total
+        limit:
+          type: integer
+          title: Limit
+        offset:
+          type: integer
+          title: Offset
+      type: object
+      required:
+      - projects
+      - total
+      - limit
+      - offset
+      title: ListProjectsResponse
+    ListS3BucketsRequest:
+      properties:
+        aws_access_key_id:
+          type: string
+          title: Aws Access Key Id
+        aws_secret_access_key:
+          type: string
+          title: Aws Secret Access Key
+        region:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Region
+      type: object
+      required:
+      - aws_access_key_id
+      - aws_secret_access_key
+      title: ListS3BucketsRequest
+      description: Request model for listing S3 buckets.
+    ListS3BucketsResponse:
+      properties:
+        buckets:
+          items:
+            $ref: '#/components/schemas/S3BucketInfo'
+          type: array
+          title: Buckets
+      type: object
+      required:
+      - buckets
+      title: ListS3BucketsResponse
+      description: Response model for listing S3 buckets.
+    ListSharepointSitesRequest:
+      properties:
+        client_id:
+          type: string
+          title: Client Id
+        client_secret:
+          type: string
+          title: Client Secret
+        tenant_id:
+          type: string
+          title: Tenant Id
+      type: object
+      required:
+      - client_id
+      - client_secret
+      - tenant_id
+      title: ListSharepointSitesRequest
+      description: Request model for listing SharePoint sites.
+    ListSharepointSitesResponse:
+      properties:
+        sites:
+          items:
+            $ref: '#/components/schemas/SharepointSiteInfo'
+          type: array
+          title: Sites
+      type: object
+      required:
+      - sites
+      title: ListSharepointSitesResponse
+      description: Response model for listing SharePoint sites.
+    ListSourceFilesRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        prefix:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Prefix
+        search_query:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Search Query
+        limit:
+          type: integer
+          maximum: 10000
+          minimum: 1
+          title: Limit
+          default: 1000
+        offset:
+          type: integer
+          minimum: 0
+          title: Offset
+          default: 0
+      type: object
+      required:
+      - data_connector_name
+      title: ListSourceFilesRequest
+      description: Request to list files from a data source.
     ListSourceMetadataRequest:
       properties:
         data_connector_name:
@@ -3231,7 +8763,6 @@ components:
       properties:
         metadata:
           additionalProperties:
-            additionalProperties: true
             type: object
           type: object
           title: Metadata
@@ -3265,7 +8796,7 @@ components:
       properties:
         taxonomies:
           items:
-            $ref: '#/components/schemas/DeasyTaxonomy'
+            $ref: '#/components/schemas/DeasyTaxonomy-Output'
           type: array
           title: Taxonomies
       type: object
@@ -3276,17 +8807,48 @@ components:
       properties:
         connectors:
           additionalProperties:
-            anyOf:
+            oneOf:
+            - $ref: '#/components/schemas/OnedriveConnectorConfig'
             - $ref: '#/components/schemas/PSQLConnectorConfig'
             - $ref: '#/components/schemas/QdrantConnectorConfig'
             - $ref: '#/components/schemas/S3ConnectorConfig'
             - $ref: '#/components/schemas/SharepointConnectorConfig'
+            discriminator:
+              propertyName: type
+              mapping:
+                OnedriveDataSourceManager: '#/components/schemas/OnedriveConnectorConfig'
+                PSQLVectorDBManager: '#/components/schemas/PSQLConnectorConfig'
+                QdrantVectorDBManager: '#/components/schemas/QdrantConnectorConfig'
+                S3DataSourceManager: '#/components/schemas/S3ConnectorConfig'
+                SharepointDataSourceManager: '#/components/schemas/SharepointConnectorConfig'
           type: object
           title: Connectors
       type: object
       required:
       - connectors
       title: ListVDBConnectorResponse
+    ListWorkflowRequest:
+      properties:
+        workflow_ids:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Workflow Ids
+      type: object
+      title: ListWorkflowRequest
+    ListWorkflowResponse:
+      properties:
+        workflows:
+          items:
+            $ref: '#/components/schemas/WorkflowPydantic-Output'
+          type: array
+          title: Workflows
+      type: object
+      required:
+      - workflows
+      title: ListWorkflowResponse
     LogicCondition:
       type: string
       enum:
@@ -3347,8 +8909,7 @@ components:
           title: Taxonomy Name
         current_tree:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Current Tree
         condition:
@@ -3378,7 +8939,7 @@ components:
           - type: integer
           - type: 'null'
           title: Max Height
-          default: 2
+          default: 1
         use_existing_tags:
           anyOf:
           - type: boolean
@@ -3479,9 +9040,15 @@ components:
           - type: 'null'
           title: Message
           default: ''
+        job_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Job Id
         suggestion:
-          additionalProperties: true
-          type: object
+          anyOf:
+          - type: object
+          - type: 'null'
           title: Suggestion
         suggested_tags:
           anyOf:
@@ -3502,8 +9069,6 @@ components:
           - type: 'null'
           title: Tag Not Found Rates
       type: object
-      required:
-      - suggestion
       title: MetadataSuggestionResponse
     OCRIngestRequest:
       properties:
@@ -3539,10 +9104,143 @@ components:
       required:
       - data_connector_name
       title: OCRIngestRequest
+    OCRSyncStatsRequest:
+      properties:
+        data_connector_names:
+          items:
+            type: string
+          type: array
+          title: Data Connector Names
+        force_refresh:
+          anyOf:
+          - type: boolean
+          - type: 'null'
+          title: Force Refresh
+          default: false
+      type: object
+      required:
+      - data_connector_names
+      title: OCRSyncStatsRequest
+    OnedriveConnectorConfig:
+      properties:
+        type:
+          type: string
+          enum:
+          - OnedriveDataSourceManager
+          const: OnedriveDataSourceManager
+          title: Type
+          default: OnedriveDataSourceManager
+        name:
+          type: string
+          title: Name
+        client_id:
+          type: string
+          title: Client Id
+        client_secret:
+          type: string
+          title: Client Secret
+        tenant_id:
+          type: string
+          title: Tenant Id
+        onedrive_site_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Onedrive Site Name
+        onedrive_site_names:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Onedrive Site Names
+        drives:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Drives
+      type: object
+      required:
+      - name
+      - client_id
+      - client_secret
+      - tenant_id
+      title: OnedriveConnectorConfig
+    OnedriveDestinationConfig:
+      properties:
+        type:
+          type: string
+          enum:
+          - OnedriveNodeDestinationManager
+          const: OnedriveNodeDestinationManager
+          title: Type
+          default: OnedriveNodeDestinationManager
+        name:
+          type: string
+          title: Name
+        client_id:
+          type: string
+          title: Client Id
+        client_secret:
+          type: string
+          title: Client Secret
+        tenant_id:
+          type: string
+          title: Tenant Id
+        onedrive_site_name:
+          type: string
+          title: Onedrive Site Name
+        documents_library_folder_name:
+          type: string
+          title: Documents Library Folder Name
+        drives:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Drives
+      type: object
+      required:
+      - name
+      - client_id
+      - client_secret
+      - tenant_id
+      - onedrive_site_name
+      - documents_library_folder_name
+      title: OnedriveDestinationConfig
+    OnedriveSiteInfo:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+        url:
+          type: string
+          title: Url
+      type: object
+      required:
+      - id
+      - name
+      - url
+      title: OnedriveSiteInfo
+      description: Information about a single OneDrive site.
+    OperatorType:
+      type: string
+      enum:
+      - in
+      - not_in
+      title: OperatorType
     PSQLConnectorConfig:
       properties:
         type:
           type: string
+          enum:
+          - PSQLVectorDBManager
           const: PSQLVectorDBManager
           title: Type
           default: PSQLVectorDBManager
@@ -3608,6 +9306,8 @@ components:
       properties:
         type:
           type: string
+          enum:
+          - PostgresNodeDestinationManager
           const: PostgresNodeDestinationManager
           title: Type
           default: PostgresNodeDestinationManager
@@ -3673,10 +9373,82 @@ components:
       - port
       - password
       title: PostgresDestinationConfig
+    ProcessingMode:
+      type: string
+      enum:
+      - deduplicate
+      - entity_resolution
+      - smart_clustering
+      - map_to_categories
+      title: ProcessingMode
+      description: Processing modes for standardization
+    ProjectResponse:
+      properties:
+        id:
+          type: string
+          format: uuid
+          title: Id
+        user_id:
+          type: string
+          title: User Id
+        name:
+          type: string
+          title: Name
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        data_source:
+          items:
+            type: string
+          type: array
+          title: Data Source
+        data_slice:
+          anyOf:
+          - type: string
+            format: uuid
+          - type: 'null'
+          title: Data Slice
+        taxonomy:
+          items:
+            type: string
+          type: array
+          title: Taxonomy
+        sensitive_data:
+          type: boolean
+          title: Sensitive Data
+          default: false
+        unique_data:
+          type: boolean
+          title: Unique Data
+          default: false
+        relevant_data:
+          type: boolean
+          title: Relevant Data
+          default: false
+        created_at:
+          type: string
+          format: date-time
+          title: Created At
+        updated_at:
+          type: string
+          format: date-time
+          title: Updated At
+      type: object
+      required:
+      - id
+      - user_id
+      - name
+      - created_at
+      - updated_at
+      title: ProjectResponse
     QdrantConnectorConfig:
       properties:
         type:
           type: string
+          enum:
+          - QdrantVectorDBManager
           const: QdrantVectorDBManager
           title: Type
           default: QdrantVectorDBManager
@@ -3769,6 +9541,47 @@ components:
       - pattern
       title: RegexPattern
       description: Model for regex pattern configuration in tags.
+    RegexPatternEvaluate:
+      properties:
+        pattern:
+          type: string
+          title: Pattern
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        output_value:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Output Value
+      type: object
+      required:
+      - pattern
+      title: RegexPatternEvaluate
+      description: A regex pattern to evaluate.
+    RetrieveVersionsRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Limit
+          default: 10000
+        offset:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Offset
+          default: 0
+      type: object
+      required:
+      - data_connector_name
+      title: RetrieveVersionsRequest
     RuleBasedRule-Input:
       properties:
         tag_value:
@@ -3821,10 +9634,22 @@ components:
       type: object
       title: RuleBasedRule
       description: Model for rule-based tag configuration.
+    S3BucketInfo:
+      properties:
+        name:
+          type: string
+          title: Name
+      type: object
+      required:
+      - name
+      title: S3BucketInfo
+      description: Information about a single S3 bucket.
     S3ConnectorConfig:
       properties:
         type:
           type: string
+          enum:
+          - S3DataSourceManager
           const: S3DataSourceManager
           title: Type
           default: S3DataSourceManager
@@ -3840,6 +9665,12 @@ components:
         name:
           type: string
           title: Name
+        region:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Region
+          default: us-east-1
       type: object
       required:
       - bucket_name
@@ -3847,10 +9678,65 @@ components:
       - aws_secret_access_key
       - name
       title: S3ConnectorConfig
+    S3DestinationConfig:
+      properties:
+        type:
+          type: string
+          enum:
+          - S3NodeDestinationManager
+          const: S3NodeDestinationManager
+          title: Type
+          default: S3NodeDestinationManager
+        name:
+          type: string
+          title: Name
+        bucket_name:
+          type: string
+          title: Bucket Name
+        aws_access_key_id:
+          type: string
+          title: Aws Access Key Id
+        aws_secret_access_key:
+          type: string
+          title: Aws Secret Access Key
+        region:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Region
+        deasy_tag_prefix:
+          type: string
+          title: Deasy Tag Prefix
+          default: deasy_
+      type: object
+      required:
+      - name
+      - bucket_name
+      - aws_access_key_id
+      - aws_secret_access_key
+      title: S3DestinationConfig
+    SetActiveConnectorRequest:
+      properties:
+        connector_name:
+          type: string
+          title: Connector Name
+        connector_type:
+          type: string
+          enum:
+          - vdb
+          - llm
+          title: Connector Type
+      type: object
+      required:
+      - connector_name
+      - connector_type
+      title: SetActiveConnectorRequest
     SharepointConnectorConfig:
       properties:
         type:
           type: string
+          enum:
+          - SharepointDataSourceManager
           const: SharepointDataSourceManager
           title: Type
           default: SharepointDataSourceManager
@@ -3869,6 +9755,13 @@ components:
         sharepoint_site_name:
           type: string
           title: Sharepoint Site Name
+        drives:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Drives
       type: object
       required:
       - name
@@ -3881,6 +9774,8 @@ components:
       properties:
         type:
           type: string
+          enum:
+          - SharepointNodeDestinationManager
           const: SharepointNodeDestinationManager
           title: Type
           default: SharepointNodeDestinationManager
@@ -3902,6 +9797,13 @@ components:
         documents_library_folder_name:
           type: string
           title: Documents Library Folder Name
+        drives:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Drives
       type: object
       required:
       - name
@@ -3911,6 +9813,230 @@ components:
       - sharepoint_site_name
       - documents_library_folder_name
       title: SharepointDestinationConfig
+    SharepointSiteInfo:
+      properties:
+        id:
+          type: string
+          title: Id
+        name:
+          type: string
+          title: Name
+        url:
+          type: string
+          title: Url
+      type: object
+      required:
+      - id
+      - name
+      - url
+      title: SharepointSiteInfo
+      description: Information about a single SharePoint site.
+    StandardizationDBRequest:
+      properties:
+        tag_name:
+          type: string
+          title: Tag Name
+        standard_mapping:
+          additionalProperties:
+            items: {}
+            type: array
+          type: object
+          title: Standard Mapping
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+      type: object
+      required:
+      - tag_name
+      - standard_mapping
+      - data_connector_name
+      title: StandardizationDBRequest
+    StandardizationDBResponse:
+      properties:
+        success:
+          type: boolean
+          title: Success
+      type: object
+      required:
+      - success
+      title: StandardizationDBResponse
+    StandardizationDeleteRequest:
+      properties:
+        tag_id:
+          type: string
+          title: Tag Id
+        taxonomy_name:
+          type: string
+          title: Taxonomy Name
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+      type: object
+      required:
+      - tag_id
+      - taxonomy_name
+      - data_connector_name
+      title: StandardizationDeleteRequest
+    StandardizationRequest:
+      properties:
+        tag_id:
+          type: string
+          title: Tag Id
+        tag_name:
+          type: string
+          title: Tag Name
+        standard_mapping:
+          type: object
+          title: Standard Mapping
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        taxonomy_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Taxonomy Name
+      type: object
+      required:
+      - tag_id
+      - tag_name
+      - standard_mapping
+      - data_connector_name
+      title: StandardizationRequest
+    StandardizationResult:
+      properties:
+        tag_name:
+          type: string
+          title: Tag Name
+          description: The name of the tag that was standardized.
+        before_count:
+          type: integer
+          title: Before Count
+          description: Number of unique values before standardization.
+        after_count:
+          type: integer
+          title: After Count
+          description: Number of unique values after standardization.
+        after_values:
+          items:
+            anyOf:
+            - type: string
+            - type: number
+            - type: integer
+          type: array
+          title: After Values
+          description: List of unique values after standardization.
+      type: object
+      required:
+      - tag_name
+      - before_count
+      - after_count
+      title: StandardizationResult
+    StandardizationSuggestRequest:
+      properties:
+        tag_names:
+          items:
+            type: string
+          type: array
+          title: Tag Names
+        description:
+          type: string
+          title: Description
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        auto_apply:
+          type: boolean
+          title: Auto Apply
+          default: false
+        existing_categories:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Existing Categories
+        processing_mode:
+          anyOf:
+          - $ref: '#/components/schemas/ProcessingMode'
+          - type: 'null'
+        custom_context:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Custom Context
+      type: object
+      required:
+      - tag_names
+      - description
+      - data_connector_name
+      title: StandardizationSuggestRequest
+    StandardizationSuggestResponse:
+      properties:
+        tag_results:
+          additionalProperties:
+            additionalProperties:
+              items: {}
+              type: array
+            type: object
+          type: object
+          title: Tag Results
+        job_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Job Id
+        status:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Status
+      type: object
+      required:
+      - tag_results
+      title: StandardizationSuggestResponse
+    SuggestDescriptionRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        tag_name:
+          type: string
+          title: Tag Name
+        context:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Context
+        current_description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Current Description
+        available_values:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Available Values
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+      type: object
+      required:
+      - data_connector_name
+      - tag_name
+      title: SuggestDescriptionRequest
+    SuggestDescriptionResponse:
+      properties:
+        suggestion:
+          type: string
+          title: Suggestion
+      type: object
+      required:
+      - suggestion
+      title: SuggestDescriptionResponse
     SuggestRegexRequest:
       properties:
         tag_data:
@@ -3959,6 +10085,40 @@ components:
           type: boolean
           title: Validate Before Return
           default: true
+        document_context:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Document Context
+        current_wrong_result:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Current Wrong Result
+        previous_attempts:
+          anyOf:
+          - items:
+              type: object
+            type: array
+          - type: 'null'
+          title: Previous Attempts
+        context_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Context Type
+        context_payload:
+          anyOf:
+          - type: object
+          - type: 'null'
+          title: Context Payload
+        evidence_examples:
+          anyOf:
+          - items:
+              $ref: '#/components/schemas/EvidenceExample'
+            type: array
+          - type: 'null'
+          title: Evidence Examples
       type: object
       required:
       - tag_data
@@ -3976,8 +10136,7 @@ components:
           title: Explanation
         validation_results:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Validation Results
         confidence_score:
@@ -3999,10 +10158,88 @@ components:
             type: array
           - type: 'null'
           title: Context Items
+        inferred_intent:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Inferred Intent
+        required_context_matches:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Required Context Matches
       type: object
       required:
       - regex
       title: SuggestRegexResponse
+    SuggestStrategyRequest:
+      properties:
+        tag_name:
+          type: string
+          title: Tag Name
+        tag_description:
+          type: string
+          title: Tag Description
+        available_values:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Available Values
+      type: object
+      required:
+      - tag_name
+      - tag_description
+      title: SuggestStrategyRequest
+      description: Request model for suggesting the optimal extraction strategy for
+        a tag.
+    SuggestStrategyResponse:
+      properties:
+        strategy:
+          type: string
+          title: Strategy
+      type: object
+      required:
+      - strategy
+      title: SuggestStrategyResponse
+      description: Response model for tag extraction strategy recommendation.
+    SyncScoreRequest:
+      properties:
+        hard_limit:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Hard Limit
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+        data_connector_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Data Connector Name
+      type: object
+      title: SyncScoreRequest
+    SyncScoreResponse:
+      properties:
+        deasy_sync_percentage:
+          type: number
+          title: Deasy Sync Percentage
+        tag_counters:
+          additionalProperties:
+            items:
+              type: integer
+            type: array
+          type: object
+          title: Tag Counters
+      type: object
+      required:
+      - deasy_sync_percentage
+      - tag_counters
+      title: SyncScoreResponse
     Tag-Input:
       properties:
         tag_id:
@@ -4045,8 +10282,7 @@ components:
           - items:
               anyOf:
               - type: string
-              - additionalProperties: true
-                type: object
+              - type: object
             type: array
           - type: 'null'
           title: Examples
@@ -4087,8 +10323,7 @@ components:
           default: []
         retry_feedback:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Retry Feedback
         date_format:
@@ -4151,6 +10386,25 @@ components:
           - type: number
           - type: 'null'
           title: Min Confidence
+        collibra_asset_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Collibra Asset Id
+        collibra_domain_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Collibra Domain Id
+        source_asset_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Asset Type
+        governance_metadata:
+          anyOf:
+          - $ref: '#/components/schemas/GovernanceMetadata'
+          - type: 'null'
       type: object
       required:
       - name
@@ -4197,8 +10451,7 @@ components:
           - items:
               anyOf:
               - type: string
-              - additionalProperties: true
-                type: object
+              - type: object
             type: array
           - type: 'null'
           title: Examples
@@ -4239,8 +10492,7 @@ components:
           default: []
         retry_feedback:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Retry Feedback
         date_format:
@@ -4303,10 +10555,53 @@ components:
           - type: number
           - type: 'null'
           title: Min Confidence
+        collibra_asset_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Collibra Asset Id
+        collibra_domain_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Collibra Domain Id
+        source_asset_type:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Source Asset Type
+        governance_metadata:
+          anyOf:
+          - $ref: '#/components/schemas/GovernanceMetadata'
+          - type: 'null'
       type: object
       required:
       - name
       title: Tag
+    TagCondition:
+      properties:
+        tag_id:
+          type: string
+          title: Tag Id
+        values:
+          anyOf:
+          - items:
+              anyOf:
+              - type: string
+              - type: number
+              - type: integer
+            type: array
+          - type: 'null'
+          title: Values
+        operator:
+          anyOf:
+          - $ref: '#/components/schemas/OperatorType'
+          - type: 'null'
+          default: in
+      type: object
+      required:
+      - tag_id
+      title: TagCondition
     TagMetadata:
       properties:
         chunk_level:
@@ -4341,6 +10636,72 @@ components:
       required:
       - tag_name
       title: TagResponse
+    TagScoresRequest:
+      properties:
+        tag_names:
+          items:
+            type: string
+          type: array
+          title: Tag Names
+        data_connector_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Data Connector Name
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+      type: object
+      required:
+      - tag_names
+      title: TagScoresRequest
+    TagScoresResponse:
+      properties:
+        scores:
+          additionalProperties:
+            anyOf:
+            - type: number
+            - type: 'null'
+          type: object
+          title: Scores
+      type: object
+      required:
+      - scores
+      title: TagScoresResponse
+    TagSearchabilityScoresRequest:
+      properties:
+        tag_names:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          title: Tag Names
+        data_connector_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Data Connector Name
+        dataslice_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Dataslice Id
+      type: object
+      title: TagSearchabilityScoresRequest
+    TagSearchabilityScoresResponse:
+      properties:
+        scores:
+          additionalProperties:
+            type: number
+          type: object
+          title: Scores
+      type: object
+      required:
+      - scores
+      title: TagSearchabilityScoresResponse
     TaskStatusRequest:
       properties:
         job_id:
@@ -4362,6 +10723,147 @@ components:
       - percent_complete
       - status
       title: TaskStatusResponse
+    TaxonomyEdge:
+      properties:
+        edge_id:
+          type: string
+          title: Edge Id
+        target_node_ids:
+          items:
+            type: string
+          type: array
+          title: Target Node Ids
+          description: IDs of the child nodes
+        conditions:
+          items:
+            $ref: '#/components/schemas/EdgeCondition'
+          type: array
+          title: Conditions
+          description: Conditions that must ALL be true for this edge to be followed
+            (AND logic)
+      type: object
+      required:
+      - target_node_ids
+      - conditions
+      title: TaxonomyEdge
+      description: 'An edge in the taxonomy graph connecting to child tags based on
+        one or more conditions.
+
+
+        For simple cases, use a single condition in the list.
+
+        For AND cases, use multiple conditions - all must be satisfied.'
+    TaxonomyGraph-Input:
+      properties:
+        nodes:
+          items:
+            $ref: '#/components/schemas/TaxonomyNode'
+          type: array
+          title: Nodes
+        edges:
+          items:
+            $ref: '#/components/schemas/TaxonomyEdge'
+          type: array
+          title: Edges
+        root_node_id:
+          type: string
+          title: Root Node Id
+          description: ID of the root node
+          default: root
+      type: object
+      title: TaxonomyGraph
+      description: "A node/edge style graph representation of a taxonomy.\n\nExample\
+        \ (simple case - single condition per edge):\n    graph = TaxonomyGraph(\n\
+        \        nodes=[\n            TaxonomyNode(node_id=\"1\", name=\"Document\
+        \ Type\", active_values=[\"Contract\", \"Invoice\"]),\n            TaxonomyNode(node_id=\"\
+        2\", name=\"Contract Type\", active_values=[\"NDA\", \"Employment\"]),\n \
+        \       ],\n        edges=[\n            TaxonomyEdge(\n                target_node_ids=[\"\
+        1\"],\n                conditions=[EdgeCondition(node_id=\"root\", tag_value_name=\"\
+        Contract\")],\n            ),\n            TaxonomyEdge(\n               \
+        \ target_node_ids=[\"2\"],\n                conditions=[EdgeCondition(node_id=\"\
+        1\", tag_value_name=\"NDA\")],\n            ),\n        ]\n    )\n\nExample\
+        \ (AND case - multiple conditions):\n    # Edge only followed when Document\
+        \ Type = Contract AND Region = US\n    TaxonomyEdge(\n        target_node_ids=[\"\
+        us_contract_node\"],\n        conditions=[\n            EdgeCondition(node_id=\"\
+        doc_type_node\", tag_value_name=\"Contract\"),\n            EdgeCondition(node_id=\"\
+        region_node\", tag_value_name=\"US\"),\n        ],\n    )"
+    TaxonomyGraph-Output:
+      properties:
+        nodes:
+          items:
+            $ref: '#/components/schemas/TaxonomyNode'
+          type: array
+          title: Nodes
+        edges:
+          items:
+            $ref: '#/components/schemas/TaxonomyEdge'
+          type: array
+          title: Edges
+        root_node_id:
+          type: string
+          title: Root Node Id
+          description: ID of the root node
+          default: root
+      type: object
+      title: TaxonomyGraph
+      description: "A node/edge style graph representation of a taxonomy.\n\nExample\
+        \ (simple case - single condition per edge):\n    graph = TaxonomyGraph(\n\
+        \        nodes=[\n            TaxonomyNode(node_id=\"1\", name=\"Document\
+        \ Type\", active_values=[\"Contract\", \"Invoice\"]),\n            TaxonomyNode(node_id=\"\
+        2\", name=\"Contract Type\", active_values=[\"NDA\", \"Employment\"]),\n \
+        \       ],\n        edges=[\n            TaxonomyEdge(\n                target_node_ids=[\"\
+        1\"],\n                conditions=[EdgeCondition(node_id=\"root\", tag_value_name=\"\
+        Contract\")],\n            ),\n            TaxonomyEdge(\n               \
+        \ target_node_ids=[\"2\"],\n                conditions=[EdgeCondition(node_id=\"\
+        1\", tag_value_name=\"NDA\")],\n            ),\n        ]\n    )\n\nExample\
+        \ (AND case - multiple conditions):\n    # Edge only followed when Document\
+        \ Type = Contract AND Region = US\n    TaxonomyEdge(\n        target_node_ids=[\"\
+        us_contract_node\"],\n        conditions=[\n            EdgeCondition(node_id=\"\
+        doc_type_node\", tag_value_name=\"Contract\"),\n            EdgeCondition(node_id=\"\
+        region_node\", tag_value_name=\"US\"),\n        ],\n    )"
+    TaxonomyNode:
+      properties:
+        node_id:
+          type: string
+          title: Node Id
+        node_type:
+          $ref: '#/components/schemas/TaxonomyNodeType'
+          default: tag
+        name:
+          type: string
+          title: Name
+          description: The tag name
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          description: Description of what this tag represents. Short and specific,
+            capturing the relevant context.
+        active_values:
+          items:
+            type: string
+          type: array
+          title: Active Values
+          description: Allowed values for this tag. Empty list means all values from
+            the tag definition are allowed.
+      type: object
+      required:
+      - name
+      title: TaxonomyNode
+      description: 'A node in the taxonomy graph representing a tag.
+
+
+        Nodes are tags with their metadata. The graph structure is defined
+
+        by edges that connect parent nodes to child nodes with optional conditions.'
+    TaxonomyNodeType:
+      type: string
+      enum:
+      - root
+      - tag
+      title: TaxonomyNodeType
+      description: Types of nodes in a taxonomy graph
     TaxonomyOperationResponse:
       properties:
         taxonomy_name:
@@ -4392,24 +10894,100 @@ components:
           - type: boolean
           - type: 'null'
           title: Validated
+        expected_value:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Expected Value
       type: object
       required:
       - text
       - should_match
       - category
       title: TestCase
+    UpdateProjectRequest:
+      properties:
+        name:
+          type: string
+          title: Name
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+        data_source:
+          items:
+            type: string
+          type: array
+          title: Data Source
+        data_slice:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Data Slice
+        taxonomy:
+          items:
+            type: string
+          type: array
+          title: Taxonomy
+        sensitive_data:
+          type: boolean
+          title: Sensitive Data
+          default: false
+        unique_data:
+          type: boolean
+          title: Unique Data
+          default: false
+        relevant_data:
+          type: boolean
+          title: Relevant Data
+          default: false
+      type: object
+      required:
+      - name
+      title: UpdateProjectRequest
+    UpdateTagRequest:
+      properties:
+        tag_data:
+          $ref: '#/components/schemas/Tag-Input'
+      type: object
+      required:
+      - tag_data
+      title: UpdateTagRequest
+    UpdateTagResponse:
+      properties:
+        tag_name:
+          type: string
+          title: Tag Name
+        tag:
+          type: object
+          title: Tag
+      type: object
+      required:
+      - tag_name
+      - tag
+      title: UpdateTagResponse
     UpdateVDBConnectorRequest:
       properties:
         connector_name:
           type: string
           title: Connector Name
         connector_body:
-          anyOf:
+          oneOf:
+          - $ref: '#/components/schemas/OnedriveConnectorConfig'
           - $ref: '#/components/schemas/PSQLConnectorConfig'
           - $ref: '#/components/schemas/QdrantConnectorConfig'
           - $ref: '#/components/schemas/S3ConnectorConfig'
           - $ref: '#/components/schemas/SharepointConnectorConfig'
           title: Connector Body
+          discriminator:
+            propertyName: type
+            mapping:
+              OnedriveDataSourceManager: '#/components/schemas/OnedriveConnectorConfig'
+              PSQLVectorDBManager: '#/components/schemas/PSQLConnectorConfig'
+              QdrantVectorDBManager: '#/components/schemas/QdrantConnectorConfig'
+              S3DataSourceManager: '#/components/schemas/S3ConnectorConfig'
+              SharepointDataSourceManager: '#/components/schemas/SharepointConnectorConfig'
       type: object
       required:
       - connector_name
@@ -4434,11 +11012,13 @@ components:
                 $ref: '#/components/schemas/TagMetadata'
               type: object
             type: object
+            title: MetadataByTagAndChunk
           - additionalProperties:
               additionalProperties:
                 $ref: '#/components/schemas/Metadata'
               type: object
             type: object
+            title: MetadataByChunk
           title: Metadata
       type: object
       required:
@@ -4496,14 +11076,26 @@ components:
           title: Taxonomy Description
         taxonomy_data:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - $ref: '#/components/schemas/TaxonomyGraph-Input'
+          - type: object
           - type: 'null'
           title: Taxonomy Data
       type: object
       required:
       - taxonomy_name
       title: UpsertTaxonomyRequest
+    UpsertWorkflowRequest:
+      properties:
+        workflow:
+          $ref: '#/components/schemas/WorkflowPydantic-Input'
+        create_unique_name:
+          type: boolean
+          title: Create Unique Name
+          default: false
+      type: object
+      required:
+      - workflow
+      title: UpsertWorkflowRequest
     ValidationError:
       properties:
         loc:
@@ -4525,7 +11117,217 @@ components:
       - msg
       - type
       title: ValidationError
+    VersioningRequest:
+      properties:
+        data_connector_name:
+          type: string
+          title: Data Connector Name
+        job_id:
+          type: string
+          title: Job Id
+      type: object
+      required:
+      - data_connector_name
+      - job_id
+      title: VersioningRequest
+    WorkflowJob:
+      properties:
+        endpoint:
+          type: string
+          title: Endpoint
+        endpoint_request_body:
+          type: object
+          title: Endpoint Request Body
+        status:
+          $ref: '#/components/schemas/WorkflowStatus'
+          default: pending
+        progress_tracker_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Progress Tracker Id
+      type: object
+      required:
+      - endpoint
+      - endpoint_request_body
+      title: WorkflowJob
+    WorkflowPydantic-Input:
+      properties:
+        id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Id
+        name:
+          type: string
+          title: Name
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          default: ''
+        status:
+          $ref: '#/components/schemas/WorkflowStatus'
+          default: pending
+        created_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Created At
+          default: '2026-05-18T12:06:28.616977'
+        updated_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Updated At
+          default: '2026-05-18T12:06:28.616981'
+        user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Id
+        raw_user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Raw User Id
+        raw_env_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Raw Env Id
+        stages:
+          items:
+            $ref: '#/components/schemas/WorkflowStage-Input'
+          type: array
+          title: Stages
+        cadence:
+          type: string
+          title: Cadence
+      type: object
+      required:
+      - name
+      - stages
+      - cadence
+      title: WorkflowPydantic
+    WorkflowPydantic-Output:
+      properties:
+        id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Id
+        name:
+          type: string
+          title: Name
+        description:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Description
+          default: ''
+        status:
+          $ref: '#/components/schemas/WorkflowStatus'
+          default: pending
+        created_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Created At
+          default: '2026-05-18T12:06:28.616977'
+        updated_at:
+          anyOf:
+          - type: string
+            format: date-time
+          - type: 'null'
+          title: Updated At
+          default: '2026-05-18T12:06:28.616981'
+        user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: User Id
+        raw_user_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Raw User Id
+        raw_env_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Raw Env Id
+        stages:
+          items:
+            $ref: '#/components/schemas/WorkflowStage-Output'
+          type: array
+          title: Stages
+        cadence:
+          type: string
+          title: Cadence
+      type: object
+      required:
+      - name
+      - stages
+      - cadence
+      title: WorkflowPydantic
+    WorkflowResponse:
+      properties:
+        workflow_id:
+          type: string
+          title: Workflow Id
+      type: object
+      required:
+      - workflow_id
+      title: WorkflowResponse
+    WorkflowStage-Input:
+      properties:
+        jobs:
+          items:
+            $ref: '#/components/schemas/WorkflowJob'
+          type: array
+          title: Jobs
+        status:
+          $ref: '#/components/schemas/WorkflowStatus'
+          default: pending
+      type: object
+      required:
+      - jobs
+      title: WorkflowStage
+    WorkflowStage-Output:
+      properties:
+        jobs:
+          items:
+            $ref: '#/components/schemas/WorkflowJob'
+          type: array
+          title: Jobs
+        status:
+          $ref: '#/components/schemas/WorkflowStatus'
+          default: pending
+      type: object
+      required:
+      - jobs
+      title: WorkflowStage
+    WorkflowStatus:
+      type: string
+      enum:
+      - pending
+      - running
+      - completed
+      - failed
+      title: WorkflowStatus
   securitySchemes:
-    HTTPBearer:
+    BasicAuth:
+      type: http
+      scheme: basic
+    BearerAuth:
       type: http
       scheme: bearer
+    UserIdAuth:
+      type: apiKey
+      in: header
+      name: X-User-ID

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -60,11 +60,18 @@ Copy and run this script to extract metadata from your documents:
 ```python
 from unstructured import UnstructuredClient
 
-# 1. Initialize the client
+# 1. Initialize the client (basic auth)
 client = UnstructuredClient(
+    base_url="https://unstructured.your-company.com/rest/unstructured",
     username="your-username",
     password="your-password",
 )
+# Alternatively, authenticate with an API token issued from the web UI:
+#   client = UnstructuredClient(
+#       base_url="https://unstructured.your-company.com/rest/unstructured",
+#       api_token="your-api-token",
+#       user_id="your-username",  # sent as the X-User-ID header
+#   )
 
 # 2. Create a data connector (S3 example)
 connector = client.data_source.create(
@@ -116,6 +123,14 @@ for result in results.metadata:
     print(f"  Summary: {result.tags.get('summary')}")
     print(f"  Key Dates: {result.tags.get('key_dates')}")
 ```
+
+<Note>
+  **About client configuration**
+
+  - **`base_url`** is required and points to your Unstructured deployment (e.g. `https://unstructured.your-company.com/rest/unstructured`). There is no default.
+  - Any constructor argument can be set via an environment variable instead: `UNSTRUCTURED_CLIENT_BASE_URL`, `UNSTRUCTURED_USERNAME`, `UNSTRUCTURED_PASSWORD`, `UNSTRUCTURED_API_TOKEN`, `UNSTRUCTURED_USER_ID`.
+  - **API tokens** are long-lived and issued from your Unstructured deployment's web UI. The SDK does not create, refresh, or revoke them.
+</Note>
 
 ## What Just Happened?
 


### PR DESCRIPTION
- **OpenAPI spec** (`deasy-openapi-stainless.yml`) - refreshed from the latest Stainless-filtered FastAPI spec. Reflects the current endpoint surface, schemas, and the multi-auth security definitions (BasicAuth, BearerAuth + UserIdAuth).
- **Quickstart** (`quickstart.mdx`) - updated the "Complete Example" client init to:
  - Show `base_url` (required by the SDK; no default).
  - Add a commented-out API token alternative (`api_token` + `user_id`, sent as the `X-User-ID` header).
  - Add a `<Note>` covering required `base_url`, env-var fallbacks for every kwarg, and that API tokens are issued from the web UI.