### PR TITLE
docs: remove image file types from supported formats

### DIFF
--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -150,7 +150,6 @@ Destinations receive enriched documents and metadata. Configure them in the app'
 | Email | `.msg` |
 | Web | `.html`, `.htm`, `.aspx`, `.xml` |
 | Data | `.json`, `.csv` |
-| Images (OCR) | `.png`, `.jpg`, `.jpeg` |
 | Plain text | `.txt`, `.log` |
 
 ## Next Steps

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -40,9 +40,6 @@ Deasy Labs can process a wide variety of document formats:
   <Card title="Data Formats" icon="brackets-curly">
     .json, .csv
   </Card>
-  <Card title="Images (OCR)" icon="image">
-    .png, .jpg, .jpeg
-  </Card>
   <Card title="Plain Text" icon="file">
     .txt, .log
   </Card>


### PR DESCRIPTION
## What

Removes the **Images (OCR)** category (`.png`, `.jpg`, `.jpeg`) from the supported file types lists in `quickstart.mdx` and `integrations/overview.mdx`.

## Why

Image support was documented but does not exist in the ingestion pipeline.

In `unstructured-app/deasie/ocr/parse/provider.py`, the `FileType` enum has no image members and `TextParserProvider` registers no image parser. There is no image parser module in `deasie/ocr/parse/`. As a result, `FileType.from_filename("scan.png")` falls through to `FileType.PLAIN` and the image bytes are handed to `PlainParser`, which parses them as text.

Note that `SUPPORTED_FILE_EXTENSIONS` in `deasie/constants.py` does still list `("image": ".png", ".jpg", ".jpeg")`, so these extensions pass the upload gate. That constant is inconsistent with the parser layer and is worth a follow up in the backend repo, but it is not something the docs should advertise.

## Scope

All three image extensions are removed rather than `.png` alone, since none of them have a parser. Leaving `.jpg` and `.jpeg` listed would be equally inaccurate.

The `OCR + source metadata` label on the introduction page is left in place. That refers to the `/ocr/ingest` pipeline stage and the PDF OCR fallback, both of which are real.